### PR TITLE
fix parameter name for ExtendedPdo

### DIFF
--- a/src/AuraSqlModule.php
+++ b/src/AuraSqlModule.php
@@ -68,7 +68,7 @@ class AuraSqlModule extends AbstractModule
 
     private function configureSingleDsn()
     {
-        $this->bind(ExtendedPdoInterface::class)->toConstructor(ExtendedPdo::class, 'dsn=pdo_dsn,username=pdo_user,passwd=pdo_pass,options=pdo_option')->in(Scope::SINGLETON);
+        $this->bind(ExtendedPdoInterface::class)->toConstructor(ExtendedPdo::class, 'dsn=pdo_dsn,username=pdo_user,password=pdo_pass,options=pdo_option')->in(Scope::SINGLETON);
         $this->bind()->annotatedWith('pdo_dsn')->toInstance($this->dsn);
         $this->bind()->annotatedWith('pdo_user')->toInstance($this->user);
         $this->bind()->annotatedWith('pdo_pass')->toInstance($this->password);


### PR DESCRIPTION
fix parameter name binding for $password in configureSingleDsn.

thanks https://twitter.com/riaf/status/703640055047323648
