### PR TITLE
Fix total results with SqlQuery

### DIFF
--- a/src/Pagerfanta/AuraSqlQueryPager.php
+++ b/src/Pagerfanta/AuraSqlQueryPager.php
@@ -7,6 +7,7 @@
 namespace Ray\AuraSqlModule\Pagerfanta;
 
 use Aura\Sql\ExtendedPdoInterface;
+use Aura\SqlQuery\Common\Select;
 use Aura\SqlQuery\Common\SelectInterface;
 use Pagerfanta\Exception\LogicException;
 use Pagerfanta\Pagerfanta;
@@ -76,6 +77,12 @@ class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, \ArrayAccess
         }
 
         $countQueryBuilderModifier = function (SelectInterface $select) {
+            if (!$select instanceof Select) {
+                throw new NotInitialized();
+            }
+            foreach ($select->getCols() as $key => $value) {
+                $select->removeCol($key);
+            }
             return $select->cols(['COUNT(*) AS total_results'])->limit(1);
         };
         $pagerfanta = new Pagerfanta(new AuraSqlQueryAdapter($this->pdo, $this->select, $countQueryBuilderModifier));

--- a/src/Pagerfanta/AuraSqlQueryPager.php
+++ b/src/Pagerfanta/AuraSqlQueryPager.php
@@ -80,7 +80,7 @@ class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, \ArrayAccess
             if (!$select instanceof Select) {
                 throw new NotInitialized();
             }
-            foreach ($select->getCols() as $key => $value) {
+            foreach (array_keys($select->getCols()) as $key) {
                 $select->removeCol($key);
             }
             return $select->cols(['COUNT(*) AS total_results'])->limit(1);

--- a/tests/Pagerfanta/AuraSqlQueryAdapterTest.php
+++ b/tests/Pagerfanta/AuraSqlQueryAdapterTest.php
@@ -73,7 +73,7 @@ class AuraSqlQueryAdapterTest extends AuraSqlQueryTestCase
     private function createAdapterToTestGetNbResults()
     {
         $countQueryBuilderModifier = function (Select $select) {
-            foreach ($select->getCols() as $key => $value) {
+            foreach (array_keys($select->getCols()) as $key) {
                 $select->removeCol($key);
             }
             return $select->cols(['COUNT(*) AS total_results'])->limit(1);

--- a/tests/Pagerfanta/AuraSqlQueryAdapterTest.php
+++ b/tests/Pagerfanta/AuraSqlQueryAdapterTest.php
@@ -73,7 +73,10 @@ class AuraSqlQueryAdapterTest extends AuraSqlQueryTestCase
     private function createAdapterToTestGetNbResults()
     {
         $countQueryBuilderModifier = function (Select $select) {
-            return $select->cols(['COUNT(DISTINCT id) AS total_results'])->limit(1);
+            foreach ($select->getCols() as $key => $value) {
+                $select->removeCol($key);
+            }
+            return $select->cols(['COUNT(*) AS total_results'])->limit(1);
         };
 
         return new AuraSqlQueryAdapter($this->pdo, $this->select, $countQueryBuilderModifier);

--- a/tests/Pagerfanta/AuraSqlQueryPagerTest.php
+++ b/tests/Pagerfanta/AuraSqlQueryPagerTest.php
@@ -5,7 +5,7 @@ use Pagerfanta\Exception\LogicException;
 use Pagerfanta\View\DefaultView;
 use Ray\AuraSqlModule\Exception\NotInitialized;
 
-class AuraSqlQueryPagerTest extends \PHPUnit_Framework_TestCase
+class AuraSqlQueryPagerTest extends AuraSqlQueryTestCase
 {
     public function setUp()
     {
@@ -39,5 +39,21 @@ class AuraSqlQueryPagerTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(LogicException::class);
         $pager = $this->pager;
         unset($pager[1]);
+    }
+
+    public function testOffsetGet()
+    {
+        $this->select = $this->qf->newSelect();
+        $this->select->cols(['p.username'])->from('posts as p');
+        $pager = $this->pager;
+        $pager->init($this->pdo, $this->select, 1, new DefaultRouteGenerator('/?page=1'));
+        $post = $pager[2];
+        $this->assertTrue($post->hasNext);
+        $this->assertTrue($post->hasPrevious);
+        $this->assertSame(1, $post->maxPerPage);
+        $this->assertSame(2, $post->current);
+        $this->assertSame(50, $post->total);
+        $expected = [['username' => 'Jon Doe']];
+        $this->assertSame($expected, $post->data);
     }
 }


### PR DESCRIPTION
SqlQueryを利用した pagination で total_results 取得が正常に動作していない問題の修正

total_results 取得の際は他のカラムを全て削除するように
（mysql>=5.7 だと sql_mode=only_full_group_by で怒られるのもあるので）
