### PR TITLE
Fix max page on AuraSqlQueryPager

### DIFF
--- a/src/Pagerfanta/AuraSqlQueryPager.php
+++ b/src/Pagerfanta/AuraSqlQueryPager.php
@@ -86,8 +86,8 @@ class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, \ArrayAccess
             return $select->cols(['COUNT(*) AS total_results'])->limit(1);
         };
         $pagerfanta = new Pagerfanta(new AuraSqlQueryAdapter($this->pdo, $this->select, $countQueryBuilderModifier));
-        $pagerfanta->setCurrentPage($page);
         $pagerfanta->setMaxPerPage($this->paging);
+        $pagerfanta->setCurrentPage($page);
 
         $pager = new Page($pagerfanta, $this->routeGenerator, $this->view, $this->viewOptions);
         $pager->maxPerPage = $pagerfanta->getMaxPerPage();

--- a/tests/Pagerfanta/AuraSqlPagerModuleTest.php
+++ b/tests/Pagerfanta/AuraSqlPagerModuleTest.php
@@ -41,6 +41,28 @@ class AuraSqlPagerModuleTest extends AbstractPdoTestCase
         $this->assertSame(50, $page->total);
     }
 
+    /**
+     * @depends testNewInstance
+     */
+    public function testArrayAccessWithMaxPage(AuraSqlPagerInterface $pager)
+    {
+        /** @var $page Page */
+        $page = $pager[50];
+        $this->assertFalse($page->hasNext);
+        $this->assertTrue($page->hasPrevious);
+        $expected = [
+                [
+                    'id' => '50',
+                    'username' => 'BEAR',
+                    'post_content' => 'entry #50',
+                ],
+        ];
+        $this->assertSame($expected, $page->data);
+        $expected = '<nav><a href="/?page=49&category=sports">Previous</a><a href="/?page=1&category=sports">1</a><span class="dots">...</span><a href="/?page=46&category=sports">46</a><a href="/?page=47&category=sports">47</a><a href="/?page=48&category=sports">48</a><a href="/?page=49&category=sports">49</a><span class="current">50</span><span class="disabled">Next</span></nav>';
+        $this->assertSame($expected, (string) $page);
+        $this->assertSame(50, $page->total);
+    }
+
     public function testInjectPager()
     {
         /** @var $fakeInject FakePagerInject */

--- a/tests/Pagerfanta/AuraSqlQueryPagerModuleTest.php
+++ b/tests/Pagerfanta/AuraSqlQueryPagerModuleTest.php
@@ -21,9 +21,10 @@ class AuraSqlQueryPagerModuleTest extends AuraSqlQueryTestCase
      */
     public function testArrayAccess(AuraSqlQueryPager $pager)
     {
-        $user = $pager[2];
-        $this->assertTrue($user->hasNext);
-        $this->assertTrue($user->hasPrevious);
+        /** @var $page Page */
+        $page = $pager[2];
+        $this->assertTrue($page->hasNext);
+        $this->assertTrue($page->hasPrevious);
         $expected = [
                 [
                     'id' => '2',
@@ -31,10 +32,33 @@ class AuraSqlQueryPagerModuleTest extends AuraSqlQueryTestCase
                     'post_content' => 'Post #2',
                 ],
         ];
-        $this->assertSame($expected, $user->data);
+        $this->assertSame($expected, $page->data);
         $expected = '<nav><a href="/?page=1&category=sports">Previous</a><a href="/?page=1&category=sports">1</a><span class="current">2</span><a href="/?page=3&category=sports">3</a><a href="/?page=4&category=sports">4</a><a href="/?page=5&category=sports">5</a><span class="dots">...</span><a href="/?page=50&category=sports">50</a><a href="/?page=3&category=sports">Next</a></nav>';
-        $this->assertSame($expected, (string) $user);
-        $this->assertSame(50, $user->total);
+        $this->assertSame($expected, (string) $page);
+        $this->assertSame(50, $page->total);
+
+    }
+
+    /**
+     * @depends testNewInstance
+     */
+    public function testArrayAccessWithMaxPage(AuraSqlQueryPager $pager)
+    {
+        /** @var $page Page */
+        $page = $pager[50];
+        $this->assertFalse($page->hasNext);
+        $this->assertTrue($page->hasPrevious);
+        $expected = [
+                [
+                    'id' => '50',
+                    'username' => 'Jon Doe',
+                    'post_content' => 'Post #50',
+                ],
+        ];
+        $this->assertSame($expected, $page->data);
+        $expected = '<nav><a href="/?page=49&category=sports">Previous</a><a href="/?page=1&category=sports">1</a><span class="dots">...</span><a href="/?page=46&category=sports">46</a><a href="/?page=47&category=sports">47</a><a href="/?page=48&category=sports">48</a><a href="/?page=49&category=sports">49</a><span class="current">50</span><span class="disabled">Next</span></nav>';
+        $this->assertSame($expected, (string) $page);
+        $this->assertSame(50, $page->total);
     }
 
     /**


### PR DESCRIPTION
SqlQuery を利用した pagination で setCurrentPage 内で perPage が 10 と扱われてしまう問題の修正

perPage の設定を先にしないと setCurrentPage 内で perPage を見ててデフォルト値の 10 が利用されてしまうので位置だけ変更しました
