### PR TITLE
Fix binding values on AuraSqlQueryAdapter

### DIFF
--- a/src/Pagerfanta/AuraSqlQueryAdapter.php
+++ b/src/Pagerfanta/AuraSqlQueryAdapter.php
@@ -52,7 +52,7 @@ class AuraSqlQueryAdapter implements AdapterInterface
         $select = $this->prepareCountQueryBuilder();
         $sql = $select->getStatement();
         $sth = $this->pdo->prepare($sql);
-        $sth->execute();
+        $sth->execute($this->select->getBindValues());
         $result = $sth->fetchColumn();
 
         return (int) $result;
@@ -77,7 +77,7 @@ class AuraSqlQueryAdapter implements AdapterInterface
             ->limit($length)
             ->getStatement();
         $sth = $this->pdo->prepare($sql);
-        $sth->execute();
+        $sth->execute($this->select->getBindValues());
         $result = $sth->fetchAll(\PDO::FETCH_ASSOC);
 
         return $result;


### PR DESCRIPTION
binding ありのクエリを AuraSqlQueryPagerFactory に渡すと
ページ取得時に以下のエラーが発生する問題の修正

```
PDOStatement::execute(): SQLSTATE[HY093]: Invalid parameter number: no parameters were bound
```
