### PR TITLE
Support named binding for replication database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,30 @@
 language: php
-
 php:
-  - 5.5
   - 5.6
+  - 7.0
+  - 7.1
   - hhvm
-  - 7
-
-install: travis_retry composer install --no-interaction --prefer-source
-
-install: travis_retry composer install --no-interaction --prefer-source
-
+sudo: false
+cache:
+  directories:
+    - $HOME/.composer/cache
+matrix:
+  include:
+    - php: 5.6
+      env: dependencies=lowest
+    - php: hhvm
+      env: dependencies=lowest
+    - php: 7.0
+      env: dependencies=lowest
+    - php: 7.1
+      env: dependencies=lowest
+before_script:
+  - composer self-update
+  - if [ -z "$dependencies" ]; then composer install; fi;
+  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest; fi;
 script:
- - if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then phpunit; fi
- - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpunit --coverage-text --coverage-clover=coverage.clover; fi
-
+ - if [ "$TRAVIS_PHP_VERSION" != "7.1" ]; then phpunit; fi
+ - if [ "$TRAVIS_PHP_VERSION" == "7.1" ]; then phpunit --coverage-text --coverage-clover=coverage.clover; fi
 after_script:
- - wget https://scrutinizer-ci.com/ocular.phar
- - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - if [ "$TRAVIS_PHP_VERSION" == "7.1" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
     "license": "MIT",
     "require": {
         "php": ">=5.5.0",
-        "ray/di": "~2.0",
-        "aura/sql": "~2.0",
-        "aura/sqlquery": "~2.4",
-        "pagerfanta/pagerfanta": "~1.0",
-        "rize/uri-template": "~0.2"
+        "ray/di": "^2.5.0",
+        "aura/sql": "^2.5.1",
+        "aura/sqlquery": "^2.7.1",
+        "pagerfanta/pagerfanta": "^1.0.4",
+        "rize/uri-template": "^0.3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "description": "aura/sql module for Ray.Di",
     "license": "MIT",
     "require": {
-        "php": ">=5.5.0",
+        "php": "~5.6|~7.0",
         "ray/di": "^2.5.0",
         "aura/sql": "^2.5.1",
         "aura/sqlquery": "^2.7.1",

--- a/src/AuraSqlReplicationDbProvider.php
+++ b/src/AuraSqlReplicationDbProvider.php
@@ -7,10 +7,17 @@
 namespace Ray\AuraSqlModule;
 
 use Aura\Sql\ConnectionLocatorInterface;
+use Ray\Di\InjectorInterface;
 use Ray\Di\ProviderInterface;
+use Ray\Di\SetContextInterface;
 
-class AuraSqlReplicationDbProvider implements ProviderInterface
+class AuraSqlReplicationDbProvider implements ProviderInterface, SetContextInterface
 {
+    /**
+     * @var InjectorInterface
+     */
+    private $injector;
+
     /**
      * @var ConnectionLocatorInterface
      */
@@ -19,9 +26,17 @@ class AuraSqlReplicationDbProvider implements ProviderInterface
     /**
      * @param ConnectionLocatorInterface $connectionLocator
      */
-    public function __construct(ConnectionLocatorInterface $connectionLocator)
+    public function __construct(InjectorInterface $injector)
     {
-        $this->connectionLocator = $connectionLocator;
+        $this->injector = $injector;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContext($context)
+    {
+        $this->connectionLocator = $this->injector->getInstance(ConnectionLocatorInterface::class, $context);
     }
 
     /**

--- a/src/AuraSqlReplicationModule.php
+++ b/src/AuraSqlReplicationModule.php
@@ -21,10 +21,19 @@ class AuraSqlReplicationModule extends AbstractModule
      */
     private $connectionLocator;
 
+    /**
+     * @var string
+     */
+    private $qualifer;
+
     public function __construct(
-        ConnectionLocatorInterface $connectionLocator = null
+        ConnectionLocatorInterface $connectionLocator = null,
+        $qualifer = '',
+        AbstractModule $module = null
     ) {
         $this->connectionLocator = $connectionLocator;
+        $this->qualifer = $qualifer;
+        parent::__construct($module);
     }
 
     /**
@@ -33,10 +42,10 @@ class AuraSqlReplicationModule extends AbstractModule
     protected function configure()
     {
         if ($this->connectionLocator) {
-            $this->bind(ConnectionLocatorInterface::class)->toInstance($this->connectionLocator);
+            $this->bind(ConnectionLocatorInterface::class)->annotatedWith($this->qualifer)->toInstance($this->connectionLocator);
         }
         // ReadOnlyConnection when GET, otherwise WriteConnection
-        $this->bind(ExtendedPdoInterface::class)->toProvider(AuraSqlReplicationDbProvider::class)->in(Scope::SINGLETON);
+        $this->bind(ExtendedPdoInterface::class)->annotatedWith($this->qualifer)->toProvider(AuraSqlReplicationDbProvider::class, $this->qualifer)->in(Scope::SINGLETON);
         // @ReadOnlyConnection @WriteConnection
         $this->installReadWriteConnection();
         // @Transactional

--- a/tests/AuraSqlReplicationModuleTest.php
+++ b/tests/AuraSqlReplicationModuleTest.php
@@ -4,6 +4,7 @@ namespace Ray\AuraSqlModule;
 
 use Aura\Sql\ConnectionLocator;
 use Aura\Sql\ExtendedPdo;
+use Aura\Sql\ExtendedPdoInterface;
 use Ray\Di\Injector;
 
 class AuraSqlReplicationModuleTest extends \PHPUnit_Framework_TestCase
@@ -58,5 +59,21 @@ class AuraSqlReplicationModuleTest extends \PHPUnit_Framework_TestCase
         $model = (new Injector(new AuraSqlReplicationModule($locator), $_ENV['TMP_DIR']))->getInstance(FakeRepModel::class);
         $this->assertInstanceOf(ExtendedPdo::class, $model->pdo);
         $this->assertSame($masterPdo, $model->pdo);
+    }
+
+    /**
+     * @dataProvider connectionProvider
+     */
+    public function testLocatorMasterWithQualifer(ConnectionLocator $locator, ExtendedPdo $masterPdo, ExtendedPdo $slavePdo)
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        /* @var  $db1Master ExtendedPdo */
+        /* @var  $db2Master ExtendedPdo */
+        list(list($locator2)) = $this->connectionProvider();
+        $db1Master = (new Injector(new AuraSqlReplicationModule($locator, 'db1'), $_ENV['TMP_DIR']))->getInstance(ExtendedPdoInterface::class, 'db1');
+        $db2Master = (new Injector(new AuraSqlReplicationModule($locator2, 'db2'), $_ENV['TMP_DIR']))->getInstance(ExtendedPdoInterface::class, 'db2');
+        $this->assertInstanceOf(ExtendedPdo::class, $db1Master);
+        $this->assertInstanceOf(ExtendedPdo::class, $db2Master);
+        $this->assertNotSame($db1Master, $db2Master);
     }
 }

--- a/tests/Pagerfanta/AuraSqlPagerModuleTest.php
+++ b/tests/Pagerfanta/AuraSqlPagerModuleTest.php
@@ -49,7 +49,7 @@ class AuraSqlPagerModuleTest extends AbstractPdoTestCase
                 ],
         ];
         $this->assertSame($expected, $page->data);
-        $expected = '<nav><a href="/?page=1&category=sports">Previous</a><a href="/?page=1&category=sports">1</a><span class="current">2</span><a href="/?page=3&category=sports">3</a><a href="/?page=4&category=sports">4</a><a href="/?page=5&category=sports">5</a><span class="dots">...</span><a href="/?page=50&category=sports">50</a><a href="/?page=3&category=sports">Next</a></nav>';
+        $expected = '<nav><a href="/?page=1&category=sports" rel="prev">Previous</a><a href="/?page=1&category=sports">1</a><span class="current">2</span><a href="/?page=3&category=sports">3</a><a href="/?page=4&category=sports">4</a><a href="/?page=5&category=sports">5</a><span class="dots">...</span><a href="/?page=50&category=sports">50</a><a href="/?page=3&category=sports" rel="next">Next</a></nav>';
         $this->assertSame($expected, (string) $page);
         $this->assertSame(50, $page->total);
     }
@@ -71,7 +71,7 @@ class AuraSqlPagerModuleTest extends AbstractPdoTestCase
                 ],
         ];
         $this->assertSame($expected, $page->data);
-        $expected = '<nav><a href="/?page=49&category=sports">Previous</a><a href="/?page=1&category=sports">1</a><span class="dots">...</span><a href="/?page=46&category=sports">46</a><a href="/?page=47&category=sports">47</a><a href="/?page=48&category=sports">48</a><a href="/?page=49&category=sports">49</a><span class="current">50</span><span class="disabled">Next</span></nav>';
+        $expected = '<nav><a href="/?page=49&category=sports" rel="prev">Previous</a><a href="/?page=1&category=sports">1</a><span class="dots">...</span><a href="/?page=46&category=sports">46</a><a href="/?page=47&category=sports">47</a><a href="/?page=48&category=sports">48</a><a href="/?page=49&category=sports">49</a><span class="current">50</span><span class="disabled">Next</span></nav>';
         $this->assertSame($expected, (string) $page);
         $this->assertSame(50, $page->total);
     }

--- a/tests/Pagerfanta/AuraSqlQueryPagerModuleTest.php
+++ b/tests/Pagerfanta/AuraSqlQueryPagerModuleTest.php
@@ -45,7 +45,7 @@ class AuraSqlQueryPagerModuleTest extends AuraSqlQueryTestCase
                 ],
         ];
         $this->assertSame($expected, $page->data);
-        $expected = '<nav><a href="/?page=1&category=sports">Previous</a><a href="/?page=1&category=sports">1</a><span class="current">2</span><a href="/?page=3&category=sports">3</a><a href="/?page=4&category=sports">4</a><a href="/?page=5&category=sports">5</a><span class="dots">...</span><a href="/?page=50&category=sports">50</a><a href="/?page=3&category=sports">Next</a></nav>';
+        $expected = '<nav><a href="/?page=1&category=sports" rel="prev">Previous</a><a href="/?page=1&category=sports">1</a><span class="current">2</span><a href="/?page=3&category=sports">3</a><a href="/?page=4&category=sports">4</a><a href="/?page=5&category=sports">5</a><span class="dots">...</span><a href="/?page=50&category=sports">50</a><a href="/?page=3&category=sports" rel="next">Next</a></nav>';
         $this->assertSame($expected, (string) $page);
         $this->assertSame(50, $page->total);
     }
@@ -67,7 +67,7 @@ class AuraSqlQueryPagerModuleTest extends AuraSqlQueryTestCase
                 ],
         ];
         $this->assertSame($expected, $page->data);
-        $expected = '<nav><a href="/?page=49&category=sports">Previous</a><a href="/?page=1&category=sports">1</a><span class="dots">...</span><a href="/?page=46&category=sports">46</a><a href="/?page=47&category=sports">47</a><a href="/?page=48&category=sports">48</a><a href="/?page=49&category=sports">49</a><span class="current">50</span><span class="disabled">Next</span></nav>';
+        $expected = '<nav><a href="/?page=49&category=sports" rel="prev">Previous</a><a href="/?page=1&category=sports">1</a><span class="dots">...</span><a href="/?page=46&category=sports">46</a><a href="/?page=47&category=sports">47</a><a href="/?page=48&category=sports">48</a><a href="/?page=49&category=sports">49</a><span class="current">50</span><span class="disabled">Next</span></nav>';
         $this->assertSame($expected, (string) $page);
         $this->assertSame(50, $page->total);
     }


### PR DESCRIPTION
## Multiple DB

You may want to inject different connection destinations on the same DB interface with `@Named($qaulifier)` annotation.
Two modules are provided. `NamedPdoModule` is for non replication use. and `AuraSqlReplicationModule` is for replication use.


```php
/**
 * @Inject
 * @Named("log_db")
 */
public function setLoggerDb(ExtendedPdoInterface $pdo)
{
    // ...
}
```


### with no replication

Use `NamedPdoModule ` to inject different named `Pdo` instance for **non** Replication use.
For instance, This module install `log_db` named `Pdo` instance.

```php
class AppModule extends AbstractModule
{
    protected function configure()
    {
        $this->install(new NamedPdoModule('log_db', 'mysql:host=localhost;dbname=log', 'username', 
    }
}
```

### with replication

You can set `$qaulifer` in 2nd parameter of AuraSqlReplicationModule.

```php
class AppModule extends AbstractModule
{
    protected function configure()
    {
        $lodDblocator = new ConnectionLocator;
        $lodDblocator->setWrite('master', new Connection('mysql:host=localhost;dbname=master', 'id', 'pass'));
        $lodDblocator->setRead('slave1',  new Connection('mysql:host=localhost;dbname=slave1', 'id', 'pass'));
        $lodDblocator->setRead('slave2',  new Connection('mysql:host=localhost;dbname=slave2', 'id', 'pass'));
        $this->install(new AuraSqlReplicationModule($lodDblocator, 'log_db'));
    }
}
```