### PR TITLE
multiple database transaction

### DIFF
--- a/src/Annotation/Transactional.php
+++ b/src/Annotation/Transactional.php
@@ -12,4 +12,5 @@ namespace Ray\AuraSqlModule\Annotation;
  */
 final class Transactional
 {
+    public $value = ['pdo'];
 }

--- a/src/Exception/InvalidTransactionalPropertyException.php
+++ b/src/Exception/InvalidTransactionalPropertyException.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * This file is part of the Ray.AuraSqlModule package
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\AuraSqlModule\Exception;
+
+class InvalidTransactionalPropertyException extends \LogicException
+{
+}

--- a/tests/Fake/FakeMultiDb.php
+++ b/tests/Fake/FakeMultiDb.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Ray\AuraSqlModule;
+
+use Aura\Sql\ExtendedPdo;
+use Aura\Sql\ExtendedPdoInterface;
+use Ray\AuraSqlModule\Annotation\AuraSql;
+use Ray\AuraSqlModule\Annotation\ReadOnlyConnection;
+use Ray\AuraSqlModule\Annotation\Transactional;
+use Ray\AuraSqlModule\Annotation\WriteConnection;
+use Ray\Di\Di\Named;
+
+class FakeMultiDb
+{
+    protected $pdo1;
+    protected $pdo2;
+    protected $pdo3;
+
+    /**
+     * @Named("pdo1=pdo1,pdo2=pdo2,pdo3=pdo3")
+     */
+    public function __construct(ExtendedPdoInterface $pdo1, ExtendedPdoInterface $pdo2, ExtendedPdoInterface $pdo3)
+    {
+        $this->pdo1 = $pdo1;
+        $this->pdo2 = $pdo2;
+        $this->pdo3 = $pdo3;
+        $this->pdo1->exec('CREATE TABLE user(name, age)');
+        $this->pdo2->exec('CREATE TABLE user(name, age)');
+        $this->pdo3->exec('CREATE TABLE user(name, age)');
+    }
+
+    /**
+     * @Transactional({"pdo1","pdo2","pdo3"})
+     */
+    public function write()
+    {
+        $stmt1 = $this->pdo1->prepare('INSERT INTO user (name, age) VALUES (?, ?)');
+        $stmt2 = $this->pdo2->prepare('INSERT INTO user (name, age) VALUES (?, ?)');
+        $stmt3 = $this->pdo3->prepare('INSERT INTO user (name, age) VALUES (?, ?)');
+        $stmt1->execute(['koriym', 18]);
+        $stmt2->execute(['ray', 19]);
+        $stmt3->execute(['bear', 20]);
+    }
+
+    public function read()
+    {
+        $users = [];
+        $users[] = $this->pdo1->fetchAll('SELECT * FROM user');
+        $users[] = $this->pdo2->fetchAll('SELECT * FROM user');
+        $users[] = $this->pdo3->fetchAll('SELECT * FROM user');
+
+        return $users;
+    }
+
+    /**
+     * @Transactional
+     */
+    public function noProp()
+    {
+    }
+}

--- a/tests/Fake/FakeMultiDbModule.php
+++ b/tests/Fake/FakeMultiDbModule.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Ray\AuraSqlModule;
+
+use Ray\Di\AbstractModule;
+
+class FakeMultiDbModule extends AbstractModule
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->install(new TransactionalModule);
+        $this->bind(FakeMultiDb::class);
+        $this->install(new NamedPdoModule('pdo1', 'sqlite::memory:'));
+        $this->install(new NamedPdoModule('pdo2', 'sqlite::memory:'));
+        $this->install(new NamedPdoModule('pdo3', 'sqlite::memory:'));
+    }
+}

--- a/tests/TransactionalTest.php
+++ b/tests/TransactionalTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ray\AuraSqlModule;
+
+use Ray\Di\Injector;
+
+class TransactionalTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \Ray\AuraSqlModule\Exception\InvalidTransactionalPropertyException
+     */
+    public function testInvalidPropertyException()
+    {
+        $ro = (new Injector(new FakeMultiDbModule))->getInstance(FakeMultiDb::class);
+        /* @var $ro FakeMultiDb */
+        $ro->noProp();
+    }
+
+    public function testMutipleTransaction()
+    {
+        $ro = (new Injector(new FakeMultiDbModule))->getInstance(FakeMultiDb::class);
+        /* @var $ro FakeMultiDb */
+        $ro->write();
+        $users = $ro->read();
+        $expected = [
+            [
+                [
+                    'name' => 'koriym',
+                    'age' => '18',
+                ],
+            ],
+            [
+                [
+                    'name' => 'ray',
+                    'age' => '19',
+                ],
+            ],
+            [
+                [
+                    'name' => 'bear',
+                    'age' => '20',
+                ],
+            ],
+        ];
+        $this->assertSame($expected, $users);
+    }
+}


### PR DESCRIPTION
In default, the property of `\PDO` is `pdo`. You can specify multiple datbase property with `@Transactional` annotation.

```php

/**
 * @Transactional({"pdo", "user_db", "log_db"})
 */
public function write()
{
    // $this->pdo->beginTransaction()
    // $this->user_db->beginTransaction()
    // $this->log_db->beginTransaction()
    
    // ...
    
    // $this->pdo->commit();
    // $this->user_db->commit();
    // $this->log_db->commit();
}
```