### PR TITLE
Fix to reset order_by caluse on countQueryBuilderModifier in AuraSqlQueryPager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 sudo: false
 php:
   - 5.6

--- a/src/Pagerfanta/AuraSqlQueryPager.php
+++ b/src/Pagerfanta/AuraSqlQueryPager.php
@@ -81,7 +81,7 @@ class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, \ArrayAccess
                 $select->removeCol($key);
             }
 
-            return $select->cols(['COUNT(*) AS total_results'])->limit(1);
+            return $select->cols(['COUNT(*) AS total_results'])->resetOrderBy()->limit(1);
         };
         $pagerfanta = new Pagerfanta(new AuraSqlQueryAdapter($this->pdo, $this->select, $countQueryBuilderModifier));
         $pagerfanta->setMaxPerPage($this->paging);

--- a/tests/Pagerfanta/AuraSqlQueryPagerTest.php
+++ b/tests/Pagerfanta/AuraSqlQueryPagerTest.php
@@ -44,7 +44,7 @@ class AuraSqlQueryPagerTest extends AuraSqlQueryTestCase
     public function testOffsetGet()
     {
         $this->select = $this->qf->newSelect();
-        $this->select->cols(['p.username'])->from('posts as p');
+        $this->select->cols(['p.username'])->from('posts as p')->orderBy(['p.username']);
         $pager = $this->pager;
         $pager->init($this->pdo, $this->select, 1, new DefaultRouteGenerator('/?page=1'));
         $post = $pager[2];


### PR DESCRIPTION
This PR is to fix "Grouping error" in AuraSqlQueryPager when passing the SELECT query with "ORDER BY" caluse.

PDOException(SQLSTATE[42803]: Grouping error: 7 ERROR:  column "foo.bar" must appear in the GROUP BY clause or be used in an aggregate function.