### PR TITLE
Fix DSN Regex for sqlite

### DIFF
--- a/src/AuraSqlModule.php
+++ b/src/AuraSqlModule.php
@@ -15,7 +15,7 @@ use Ray\Di\Scope;
 
 class AuraSqlModule extends AbstractModule
 {
-    const PARSE_PDO_DSN_REGEX = '/(.*?)\:(host|server)=.*?;(.*)/i';
+    const PARSE_PDO_DSN_REGEX = '/(.*?)\:(?:(host|server)=.*?;)?(.*)/i';
 
     /**
      * @var string

--- a/tests/AuraSqlModuleTest.php
+++ b/tests/AuraSqlModuleTest.php
@@ -20,6 +20,27 @@ class AuraSqlModuleTest extends \PHPUnit_Framework_TestCase
         (new DiCompiler(new AuraSqlModule('sqlite::memory:'), $_ENV['TMP_DIR']))->compile();
     }
 
+    public function testMysql()
+    {
+        $fakeInject = (new Injector(new AuraSqlModule('mysql:host=localhost;dbname=master'), $_ENV['TMP_DIR']))->getInstance(FakeQueryInject::class);
+        list($db,) = $fakeInject->get();
+        $this->assertEquals('mysql', $db);
+    }
+
+    public function testPgsql()
+    {
+        $fakeInject = (new Injector(new AuraSqlModule('pgsql:host=localhost;dbname=master'), $_ENV['TMP_DIR']))->getInstance(FakeQueryInject::class);
+        list($db,) = $fakeInject->get();
+        $this->assertEquals('pgsql', $db);
+    }
+
+    public function testSqlite()
+    {
+        $fakeInject = (new Injector(new AuraSqlModule('sqlite:memory:'), $_ENV['TMP_DIR']))->getInstance(FakeQueryInject::class);
+        list($db,) = $fakeInject->get();
+        $this->assertEquals('sqlite', $db);
+    }
+
     public function testSlaveModule()
     {
         $module = new AuraSqlModule('mysql:host=localhost;dbname=testdb', 'root', '', 'slave1,slave2');

--- a/tests/AuraSqlQueryModuleTest.php
+++ b/tests/AuraSqlQueryModuleTest.php
@@ -53,7 +53,7 @@ class AuraSqlQueryModuleTest extends \PHPUnit_Framework_TestCase
     {
         /** @var $fakeInject FakeQueryInject */
         $fakeInject = (new Injector(new AuraSqlQueryModule('mysql')))->getInstance(FakeQueryInject::class);
-        list($select, $insert, $update, $delete) = $fakeInject->get();
+        list(,$select, $insert, $update, $delete) = $fakeInject->get();
         $this->assertInstanceOf(SelectInterface::class, $select);
         $this->assertInstanceOf(InsertInterface::class, $insert);
         $this->assertInstanceOf(UpdateInterface::class, $update);

--- a/tests/Fake/FakeQueryInject.php
+++ b/tests/Fake/FakeQueryInject.php
@@ -2,6 +2,8 @@
 
 namespace Ray\AuraSqlModule;
 
+use Ray\AuraSqlModule\Annotation\AuraSqlQueryConfig;
+
 class FakeQueryInject
 {
     use AuraSqlSelectInject;
@@ -9,9 +11,25 @@ class FakeQueryInject
     use AuraSqlUpdateInject;
     use AuraSqlDeleteInject;
 
+    /**
+     * @var string
+     */
+    private $db;
+
+    /**
+     * @AuraSqlQueryConfig
+     *
+     * @param string $db
+     */
+    public function __construct($db)
+    {
+        $this->db = $db;
+    }
+
     public function get()
     {
         return [
+            $this->db,
             $this->select,
             $this->insert,
             $this->update,


### PR DESCRIPTION
dsn文字列をチェックする正規表現でsqlite dsnがマッチしなかったため修正しました。
ご確認お願いします。