### PR TITLE
Update transaction interceptor  for ray/query module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "rize/uri-template": "^0.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7"
+        "phpunit/phpunit": "^6.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Ray\\AuraSqlModule\\": "src/"
+            "Ray\\AuraSqlModule\\": ["src/", "src-deprecated"]
         },
         "files": [
             "src-files/uri_template.php"

--- a/src-deprecated/PropTransaction.php
+++ b/src-deprecated/PropTransaction.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of the Ray.AuraSqlModule package
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\AuraSqlModule;
+
+use Aura\Sql\ExtendedPdoInterface;
+use Ray\Aop\MethodInvocation;
+use Ray\AuraSqlModule\Annotation\Transactional;
+use Ray\AuraSqlModule\Exception\InvalidTransactionalPropertyException;
+use Ray\AuraSqlModule\Exception\RollbackException;
+
+final class PropTransaction
+{
+    public function __invoke(MethodInvocation $invocation, Transactional $transactional)
+    {
+        $object = $invocation->getThis();
+        $transactions = [];
+        foreach ($transactional->value as $prop) {
+            $transactions[] = $this->begin($object, $prop);
+        }
+        try {
+            $result = $invocation->proceed();
+            foreach ($transactions as $db) {
+                $db->commit();
+            }
+        } catch (\PDOException $e) {
+            foreach ($transactions as $db) {
+                $db->rollback();
+            }
+            throw new RollbackException($e->getMessage(), 0, $e);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param object $object the object having pdo
+     * @param string $prop   the name of pdo property
+     *
+     * @throws InvalidTransactionalPropertyException
+     *
+     * @return \Pdo
+     */
+    private function begin($object, $prop) : ExtendedPdoInterface
+    {
+        try {
+            $ref = new \ReflectionProperty($object, $prop);
+        } catch (\ReflectionException $e) {
+            throw new InvalidTransactionalPropertyException($prop, 0, $e);
+        }
+        $ref->setAccessible(true);
+        $db = $ref->getValue($object);
+        $db->beginTransaction();
+
+        return $db;
+    }
+}

--- a/src/Annotation/Transactional.php
+++ b/src/Annotation/Transactional.php
@@ -12,5 +12,10 @@ namespace Ray\AuraSqlModule\Annotation;
  */
 final class Transactional
 {
+    /**
+     * @var array
+     *
+     * @deprecated
+     */
     public $value = ['pdo'];
 }

--- a/src/AuraSqlLocatorModule.php
+++ b/src/AuraSqlLocatorModule.php
@@ -34,11 +34,13 @@ class AuraSqlLocatorModule extends AbstractModule
     public function __construct(
         ConnectionLocatorInterface $connectionLocator = null,
         array $readMethods = [],
-        array $writeMethods = []
+        array $writeMethods = [],
+        AbstractModule $module = null
     ) {
         $this->connectionLocator = $connectionLocator;
         $this->readMethods = $readMethods;
         $this->writeMethods = $writeMethods;
+        parent::__construct($module);
     }
 
     /**

--- a/src/AuraSqlMasterModule.php
+++ b/src/AuraSqlMasterModule.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of the Ray.AuraSqlModule package
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\AuraSqlModule;
+
+use Aura\Sql\ExtendedPdo;
+use Aura\Sql\ExtendedPdoInterface;
+use Ray\Di\AbstractModule;
+use Ray\Di\Scope;
+
+class AuraSqlMasterModule extends AbstractModule
+{
+    /**
+     * @var string
+     */
+    private $dsn;
+
+    /**
+     * @var string
+     */
+    private $user;
+
+    /**
+     * @var string
+     */
+    private $password;
+
+    /**
+     * @param string $dsn
+     * @param string $user
+     * @param string $password
+     */
+    public function __construct($dsn, $user = '', $password = '', AbstractModule $module = null)
+    {
+        $this->dsn = $dsn;
+        $this->user = $user;
+        $this->password = $password;
+        parent::__construct($module);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->bind(ExtendedPdoInterface::class)->toConstructor(ExtendedPdo::class, 'dsn=pdo_dsn,username=pdo_user,password=pdo_pass,options=pdo_option')->in(Scope::SINGLETON);
+        $this->bind()->annotatedWith('pdo_dsn')->toInstance($this->dsn);
+        $this->bind()->annotatedWith('pdo_user')->toInstance($this->user);
+        $this->bind()->annotatedWith('pdo_pass')->toInstance($this->password);
+        $this->bind()->annotatedWith('pdo_option')->toInstance([]);
+    }
+}

--- a/src/AuraSqlModule.php
+++ b/src/AuraSqlModule.php
@@ -62,7 +62,7 @@ class AuraSqlModule extends AbstractModule
         $this->install(new TransactionalModule);
         $this->install(new AuraSqlPagerModule());
         preg_match(self::PARSE_PDO_DSN_REGEX, $this->dsn, $parts);
-        $dbType = isset($parts[1]) ? $parts[1] : '';
+        $dbType = $parts[1] ?? '';
         $this->install(new AuraSqlQueryModule($dbType));
     }
 

--- a/src/Pagerfanta/AuraSqlQueryPager.php
+++ b/src/Pagerfanta/AuraSqlQueryPager.php
@@ -7,7 +7,6 @@
 namespace Ray\AuraSqlModule\Pagerfanta;
 
 use Aura\Sql\ExtendedPdoInterface;
-use Aura\SqlQuery\Common\Select;
 use Aura\SqlQuery\Common\SelectInterface;
 use Pagerfanta\Exception\LogicException;
 use Pagerfanta\Pagerfanta;

--- a/src/TransactionalInterceptor.php
+++ b/src/TransactionalInterceptor.php
@@ -7,20 +7,19 @@
 namespace Ray\AuraSqlModule;
 
 use Aura\Sql\ExtendedPdoInterface;
-use Aura\Sql\PdoInterface;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
-use Ray\AuraSqlModule\Exception\InvalidTransactionalPropertyException;
+use Ray\AuraSqlModule\Annotation\Transactional;
 use Ray\AuraSqlModule\Exception\RollbackException;
 
 class TransactionalInterceptor implements MethodInterceptor
 {
     /**
-     * @var PdoInterface
+     * @var ExtendedPdoInterface
      */
     private $pdo;
 
-    public function __construct(ExtendedPdoInterface $pdo)
+    public function __construct(ExtendedPdoInterface $pdo = null)
     {
         $this->pdo = $pdo;
     }
@@ -30,38 +29,23 @@ class TransactionalInterceptor implements MethodInterceptor
      */
     public function invoke(MethodInvocation $invocation)
     {
+        /* @var Transactional $transactional */
+        $transactional = $invocation->getMethod()->getAnnotation(Transactional::class);
+        if (count($transactional->value) > 0) {
+            return (new PropTransaction)($invocation, $transactional);
+        }
+        if (! $this->pdo instanceof ExtendedPdoInterface) {
+            return $invocation->proceed();
+        }
         try {
             $this->pdo->beginTransaction();
             $result = $invocation->proceed();
             $this->pdo->commit();
-
-            return $result;
         } catch (\PDOException $e) {
             $this->pdo->rollBack();
             throw new RollbackException($e->getMessage(), 0, $e);
         }
+
+        return $result;
     }
 }
-//}
-//    /**
-//     * @param object $object the object having pdo
-//     * @param string $prop   the name of pdo property
-//     *
-//     * @throws InvalidTransactionalPropertyException
-//     *
-//     * @return \Pdo
-//     */
-//    private function beginTransaction($object, $prop)
-//    {
-//        try {
-//            $ref = new \ReflectionProperty($object, $prop);
-//        } catch (\ReflectionException $e) {
-//            throw new InvalidTransactionalPropertyException($prop, 0, $e);
-//        }
-//        $ref->setAccessible(true);
-//        $db = $ref->getValue($object);
-//        $db->beginTransaction();
-//
-//        return $db;
-//    }
-//}

--- a/src/TransactionalInterceptor.php
+++ b/src/TransactionalInterceptor.php
@@ -6,60 +6,62 @@
  */
 namespace Ray\AuraSqlModule;
 
+use Aura\Sql\ExtendedPdoInterface;
+use Aura\Sql\PdoInterface;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
-use Ray\AuraSqlModule\Annotation\Transactional;
 use Ray\AuraSqlModule\Exception\InvalidTransactionalPropertyException;
 use Ray\AuraSqlModule\Exception\RollbackException;
 
 class TransactionalInterceptor implements MethodInterceptor
 {
     /**
+     * @var PdoInterface
+     */
+    private $pdo;
+
+    public function __construct(ExtendedPdoInterface $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function invoke(MethodInvocation $invocation)
     {
-        $transactional = $invocation->getMethod()->getAnnotation(Transactional::class);
-        $object = $invocation->getThis();
-        $transactions = [];
-        /* @var $transactions \PDO[] */
-        foreach ($transactional->value as $prop) {
-            $transactions[] = $this->beginTransaction($object, $prop);
-        }
         try {
+            $this->pdo->beginTransaction();
             $result = $invocation->proceed();
-            foreach ($transactions as $db) {
-                $db->commit();
-            }
-        } catch (\Exception $e) {
-            foreach ($transactions as $db) {
-                $db->rollback();
-            }
-            throw new RollbackException($e, 0, $e);
+            $this->pdo->commit();
+
+            return $result;
+        } catch (\PDOException $e) {
+            $this->pdo->rollBack();
+            throw new RollbackException($e->getMessage(), 0, $e);
         }
-
-        return $result;
-    }
-
-    /**
-     * @param object $object the object having pdo
-     * @param string $prop   the name of pdo property
-     *
-     * @throws InvalidTransactionalPropertyException
-     *
-     * @return \Pdo
-     */
-    private function beginTransaction($object, $prop)
-    {
-        try {
-            $ref = new \ReflectionProperty($object, $prop);
-        } catch (\ReflectionException $e) {
-            throw new InvalidTransactionalPropertyException($prop, 0, $e);
-        }
-        $ref->setAccessible(true);
-        $db = $ref->getValue($object);
-        $db->beginTransaction();
-
-        return $db;
     }
 }
+//}
+//    /**
+//     * @param object $object the object having pdo
+//     * @param string $prop   the name of pdo property
+//     *
+//     * @throws InvalidTransactionalPropertyException
+//     *
+//     * @return \Pdo
+//     */
+//    private function beginTransaction($object, $prop)
+//    {
+//        try {
+//            $ref = new \ReflectionProperty($object, $prop);
+//        } catch (\ReflectionException $e) {
+//            throw new InvalidTransactionalPropertyException($prop, 0, $e);
+//        }
+//        $ref->setAccessible(true);
+//        $db = $ref->getValue($object);
+//        $db->beginTransaction();
+//
+//        return $db;
+//    }
+//}

--- a/tests/AuraSqlLocatorModuleTest.php
+++ b/tests/AuraSqlLocatorModuleTest.php
@@ -3,10 +3,11 @@ namespace Ray\AuraSqlModule;
 
 use Aura\Sql\ConnectionLocator;
 use Aura\Sql\ExtendedPdo;
+use PHPUnit\Framework\TestCase;
 use Ray\AuraSqlModule\Exception\RollbackException;
 use Ray\Di\Injector;
 
-class AuraSqlLocatorModuleTest extends \PHPUnit_Framework_TestCase
+class AuraSqlLocatorModuleTest extends TestCase
 {
     /**
      * @var ExtendedPdo
@@ -66,7 +67,7 @@ class AuraSqlLocatorModuleTest extends \PHPUnit_Framework_TestCase
 
     public function testTransactional()
     {
-        $this->setExpectedException(RollbackException::class);
+        $this->expectException(RollbackException::class);
         $this->model->dbError();
     }
 }

--- a/tests/AuraSqlLocatorModuleTest.php
+++ b/tests/AuraSqlLocatorModuleTest.php
@@ -6,6 +6,7 @@ use Aura\Sql\ExtendedPdo;
 use PHPUnit\Framework\TestCase;
 use Ray\AuraSqlModule\Exception\RollbackException;
 use Ray\Di\Injector;
+use Ray\Di\NullModule;
 
 class AuraSqlLocatorModuleTest extends TestCase
 {
@@ -39,7 +40,10 @@ class AuraSqlLocatorModuleTest extends TestCase
         $this->masterPdo = $master();
         $locator->setWrite('master', $master);
         $this->locator = $locator;
-        $this->model = (new Injector(new AuraSqlLocatorModule($this->locator, ['read'], ['write']), $_ENV['TMP_DIR']))->getInstance(FakeModel::class);
+        $modue = new NullModule;
+        $modue->install(new AuraSqlMasterModule('sqlite::memory:', '', ''));
+        $modue->install(new AuraSqlLocatorModule($this->locator, ['read'], ['write']));
+        $this->model = (new Injector($modue))->getInstance(FakeModel::class);
     }
 
     public function testLocator()

--- a/tests/AuraSqlModuleTest.php
+++ b/tests/AuraSqlModuleTest.php
@@ -27,22 +27,22 @@ class AuraSqlModuleTest extends TestCase
     public function testMysql()
     {
         $fakeInject = (new Injector(new AuraSqlModule('mysql:host=localhost;dbname=master'), $_ENV['TMP_DIR']))->getInstance(FakeQueryInject::class);
-        list($db,) = $fakeInject->get();
-        $this->assertEquals('mysql', $db);
+        list($db) = $fakeInject->get();
+        $this->assertSame('mysql', $db);
     }
 
     public function testPgsql()
     {
         $fakeInject = (new Injector(new AuraSqlModule('pgsql:host=localhost;dbname=master'), $_ENV['TMP_DIR']))->getInstance(FakeQueryInject::class);
-        list($db,) = $fakeInject->get();
-        $this->assertEquals('pgsql', $db);
+        list($db) = $fakeInject->get();
+        $this->assertSame('pgsql', $db);
     }
 
     public function testSqlite()
     {
         $fakeInject = (new Injector(new AuraSqlModule('sqlite:memory:'), $_ENV['TMP_DIR']))->getInstance(FakeQueryInject::class);
-        list($db,) = $fakeInject->get();
-        $this->assertEquals('sqlite', $db);
+        list($db) = $fakeInject->get();
+        $this->assertSame('sqlite', $db);
     }
 
     public function testSlaveModule()

--- a/tests/AuraSqlModuleTest.php
+++ b/tests/AuraSqlModuleTest.php
@@ -4,10 +4,12 @@ namespace Ray\AuraSqlModule;
 use Aura\Sql\ConnectionLocatorInterface;
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
+use PHPUnit\Framework\TestCase;
 use Ray\Compiler\DiCompiler;
+use Ray\Compiler\ScriptInjector;
 use Ray\Di\Injector;
 
-class AuraSqlModuleTest extends \PHPUnit_Framework_TestCase
+class AuraSqlModuleTest extends TestCase
 {
     public function testModule()
     {
@@ -18,6 +20,8 @@ class AuraSqlModuleTest extends \PHPUnit_Framework_TestCase
     public function testCompile()
     {
         (new DiCompiler(new AuraSqlModule('sqlite::memory:'), $_ENV['TMP_DIR']))->compile();
+        $pdo = (new ScriptInjector($_ENV['TMP_DIR']))->getInstance(ExtendedPdoInterface::class);
+        $this->assertInstanceOf(ExtendedPdoInterface::class, $pdo);
     }
 
     public function testMysql()

--- a/tests/AuraSqlQueryModuleTest.php
+++ b/tests/AuraSqlQueryModuleTest.php
@@ -54,7 +54,7 @@ class AuraSqlQueryModuleTest extends TestCase
     {
         /** @var $fakeInject FakeQueryInject */
         $fakeInject = (new Injector(new AuraSqlQueryModule('mysql')))->getInstance(FakeQueryInject::class);
-        list(,$select, $insert, $update, $delete) = $fakeInject->get();
+        list(, $select, $insert, $update, $delete) = $fakeInject->get();
         $this->assertInstanceOf(SelectInterface::class, $select);
         $this->assertInstanceOf(InsertInterface::class, $insert);
         $this->assertInstanceOf(UpdateInterface::class, $update);

--- a/tests/AuraSqlQueryModuleTest.php
+++ b/tests/AuraSqlQueryModuleTest.php
@@ -9,10 +9,11 @@ use Aura\SqlQuery\Common\Select;
 use Aura\SqlQuery\Common\SelectInterface;
 use Aura\SqlQuery\Common\Update;
 use Aura\SqlQuery\Common\UpdateInterface;
+use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 use Ray\Di\InjectorInterface;
 
-class AuraSqlQueryModuleTest extends \PHPUnit_Framework_TestCase
+class AuraSqlQueryModuleTest extends TestCase
 {
     /**
      * @var InjectorInterface

--- a/tests/AuraSqlReplicationModuleTest.php
+++ b/tests/AuraSqlReplicationModuleTest.php
@@ -4,9 +4,10 @@ namespace Ray\AuraSqlModule;
 use Aura\Sql\ConnectionLocator;
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
+use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 
-class AuraSqlReplicationModuleTest extends \PHPUnit_Framework_TestCase
+class AuraSqlReplicationModuleTest extends TestCase
 {
     /**
      * @var ExtendedPdo

--- a/tests/Fake/FakeMultiDb.php
+++ b/tests/Fake/FakeMultiDb.php
@@ -51,11 +51,4 @@ class FakeMultiDb
 
         return $users;
     }
-
-    /**
-     * @Transactional
-     */
-    public function noProp()
-    {
-    }
 }

--- a/tests/NamedPdoModuleTest.php
+++ b/tests/NamedPdoModuleTest.php
@@ -3,9 +3,10 @@ namespace Ray\AuraSqlModule;
 
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
+use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 
-class NamedPdoModuleTest extends \PHPUnit_Framework_TestCase
+class NamedPdoModuleTest extends TestCase
 {
     public function testModule()
     {

--- a/tests/Pagerfanta/AbstractPdoTestCase.php
+++ b/tests/Pagerfanta/AbstractPdoTestCase.php
@@ -2,8 +2,9 @@
 namespace Ray\AuraSqlModule\Pagerfanta;
 
 use Aura\Sql\ExtendedPdo;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractPdoTestCase extends \PHPUnit_Framework_TestCase
+abstract class AbstractPdoTestCase extends TestCase
 {
     /**
      * @var ExtendedPdo

--- a/tests/Pagerfanta/AuraSqlPagerTest.php
+++ b/tests/Pagerfanta/AuraSqlPagerTest.php
@@ -3,9 +3,10 @@ namespace Ray\AuraSqlModule\Pagerfanta;
 
 use Pagerfanta\Exception\LogicException;
 use Pagerfanta\View\DefaultView;
+use PHPUnit\Framework\TestCase;
 use Ray\AuraSqlModule\Exception\NotInitialized;
 
-class AuraSqlPagerTest extends \PHPUnit_Framework_TestCase
+class AuraSqlPagerTest extends TestCase
 {
     /**
      * @var AuraSqlPager
@@ -20,28 +21,28 @@ class AuraSqlPagerTest extends \PHPUnit_Framework_TestCase
 
     public function testExecute()
     {
-        $this->setExpectedException(NotInitialized::class);
+        $this->expectException(NotInitialized::class);
         $pager = $this->pager;
         $pager[1];
     }
 
     public function testOffsetExists()
     {
-        $this->setExpectedException(LogicException::class);
+        $this->expectException(LogicException::class);
         $pager = $this->pager;
         isset($pager[1]);
     }
 
     public function testOffsetSet()
     {
-        $this->setExpectedException(LogicException::class);
+        $this->expectException(LogicException::class);
         $pager = $this->pager;
         $pager[1] = 1;
     }
 
     public function testOffsetUnset()
     {
-        $this->setExpectedException(LogicException::class);
+        $this->expectException(LogicException::class);
         $pager = $this->pager;
         unset($pager[1]);
     }

--- a/tests/Pagerfanta/AuraSqlQueryPagerTest.php
+++ b/tests/Pagerfanta/AuraSqlQueryPagerTest.php
@@ -15,28 +15,28 @@ class AuraSqlQueryPagerTest extends AuraSqlQueryTestCase
 
     public function testExecute()
     {
-        $this->setExpectedException(NotInitialized::class);
+        $this->expectException(NotInitialized::class);
         $pager = $this->pager;
         $pager[1];
     }
 
     public function testOffsetExists()
     {
-        $this->setExpectedException(LogicException::class);
+        $this->expectException(LogicException::class);
         $pager = $this->pager;
         isset($pager[1]);
     }
 
     public function testOffsetSet()
     {
-        $this->setExpectedException(LogicException::class);
+        $this->expectException(LogicException::class);
         $pager = $this->pager;
         $pager[1] = 1;
     }
 
     public function testOffsetUnset()
     {
-        $this->setExpectedException(LogicException::class);
+        $this->expectException(LogicException::class);
         $pager = $this->pager;
         unset($pager[1]);
     }

--- a/tests/Pagerfanta/AuraSqlQueryTestCase.php
+++ b/tests/Pagerfanta/AuraSqlQueryTestCase.php
@@ -4,8 +4,9 @@ namespace Ray\AuraSqlModule\Pagerfanta;
 use Aura\Sql\ExtendedPdo;
 use Aura\SqlQuery\Common\Select;
 use Aura\SqlQuery\QueryFactory;
+use PHPUnit\Framework\TestCase;
 
-abstract class AuraSqlQueryTestCase extends \PHPUnit_Framework_TestCase
+abstract class AuraSqlQueryTestCase extends TestCase
 {
     /**
      * @var ExtendedPdo

--- a/tests/TransactionalTest.php
+++ b/tests/TransactionalTest.php
@@ -1,15 +1,15 @@
 <?php
 namespace Ray\AuraSqlModule;
 
+use PHPUnit\Framework\TestCase;
+use Ray\AuraSqlModule\Exception\InvalidTransactionalPropertyException;
 use Ray\Di\Injector;
 
-class TransactionalTest extends \PHPUnit_Framework_TestCase
+class TransactionalTest extends TestCase
 {
-    /**
-     * @expectedException \Ray\AuraSqlModule\Exception\InvalidTransactionalPropertyException
-     */
     public function testInvalidPropertyException()
     {
+        $this->expectException(InvalidTransactionalPropertyException::class);
         $ro = (new Injector(new FakeMultiDbModule))->getInstance(FakeMultiDb::class);
         /* @var $ro FakeMultiDb */
         $ro->noProp();

--- a/tests/TransactionalTest.php
+++ b/tests/TransactionalTest.php
@@ -2,19 +2,10 @@
 namespace Ray\AuraSqlModule;
 
 use PHPUnit\Framework\TestCase;
-use Ray\AuraSqlModule\Exception\InvalidTransactionalPropertyException;
 use Ray\Di\Injector;
 
 class TransactionalTest extends TestCase
 {
-    public function testInvalidPropertyException()
-    {
-        $this->expectException(InvalidTransactionalPropertyException::class);
-        $ro = (new Injector(new FakeMultiDbModule))->getInstance(FakeMultiDb::class);
-        /* @var $ro FakeMultiDb */
-        $ro->noProp();
-    }
-
     public function testMutipleTransaction()
     {
         $ro = (new Injector(new FakeMultiDbModule))->getInstance(FakeMultiDb::class);


### PR DESCRIPTION
PDOインスタンスをオブジェクトのプロパティから取得するのではなく、DIでシングルトンとして取得します。

Instead of getting the PDO instance from the properties of the object, get it as a singleton in DI.