### PR TITLE
Use rewrited count query for sql with params

### DIFF
--- a/src/Pagerfanta/ExtendedPdoAdapter.php
+++ b/src/Pagerfanta/ExtendedPdoAdapter.php
@@ -52,7 +52,7 @@ class ExtendedPdoAdapter implements AdapterInterface
 
             return ! $count ? 0 : (int) $count;
         }
-        $count = $this->pdo->query($countQuery)->fetchColumn();
+        $count = $this->pdo->fetchValue($countQuery);
 
         return ! $count ? 0 : (int) $count;
     }

--- a/src/Pagerfanta/ExtendedPdoAdapter.php
+++ b/src/Pagerfanta/ExtendedPdoAdapter.php
@@ -48,13 +48,9 @@ class ExtendedPdoAdapter implements AdapterInterface
             return ! $result ? 0 : \count($result);
         }
         if ($this->params) {
-            /** @var ExtendedPdo $pdo */
-            $pdo = $this->pdo;
-            $sth = $pdo->prepareWithValues($countQuery, $this->params);
-            $sth->execute();
-            $result = $sth->fetchColumn();
+            $count = $this->pdo->fetchValue($countQuery, $this->params);
 
-            return ! $result ? 0 : (int) $result;
+            return ! $count ? 0 : (int) $count;
         }
         $count = $this->pdo->query($countQuery)->fetchColumn();
 

--- a/src/Pagerfanta/ExtendedPdoAdapter.php
+++ b/src/Pagerfanta/ExtendedPdoAdapter.php
@@ -50,11 +50,11 @@ class ExtendedPdoAdapter implements AdapterInterface
         if ($this->params) {
             /** @var ExtendedPdo $pdo */
             $pdo = $this->pdo;
-            $sth = $pdo->prepareWithValues($this->sql, $this->params);
+            $sth = $pdo->prepareWithValues($countQuery, $this->params);
             $sth->execute();
-            $result = $sth->fetchAll();
+            $result = $sth->fetchColumn();
 
-            return ! $result ? 0 : \count($result);
+            return ! $result ? 0 : (int) $result;
         }
         $count = $this->pdo->query($countQuery)->fetchColumn();
 


### PR DESCRIPTION
プレースホルダー付きのSQLにパラメータを指定する必要がある場合はすべて、rewriteされたCOUNTクエリが使われずに、PHPで count()関数が呼ばれるような仕様になってしまっている問題の修正です。
