### PR TITLE
Allow array type for a parameter $params

### DIFF
--- a/src/Pagerfanta/AuraSqlPagerFactoryInterface.php
+++ b/src/Pagerfanta/AuraSqlPagerFactoryInterface.php
@@ -9,7 +9,7 @@ use Aura\Sql\ExtendedPdoInterface;
 interface AuraSqlPagerFactoryInterface
 {
     /**
-     * @param array<int|string> $params
+     * @param array<int|string|array<int|string>> $params
      */
     public function newInstance(ExtendedPdoInterface $pdo, string $sql, array $params, int $paging, string $uriTemplate): AuraSqlPagerInterface;
 }


### PR DESCRIPTION
phpstan outputs error below when I use an array parameter such as this code.

### Code
```
$pager = $this->pagerFactory->newInstance(
    $this->pdo,
    'SELECT * FROM posts WHERE category IN (:categories)',
    [
        'categories' => ['categoryA', 'categoryB'],
    ],
    1,
    '/{?page}'
);
```

### phpstan Error
```
 ------ ----------------------------------------------------------------------- 
  Line
 ------ ----------------------------------------------------------------------- 
  51     Parameter #3 $params of method                                         
         Ray\AuraSqlModule\Pagerfanta\AuraSqlPagerFactoryInterface::newInstanc  
         e() expects array<int|string>, array<string, array<int,                
         string>|int|string> given.                                             
 ------ ----------------------------------------------------------------------- 
```

