### PR TITLE
Bump ray/aop version to 2.10.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^7.3 || ^8.0",
         "ext-pdo": "*",
         "ray/di": "^2.11.3",
-        "ray/aop": "^2.10.3",
+        "ray/aop": "^2.10.4",
         "aura/sql": "^3.0",
         "aura/sqlquery": "^2.7.1",
         "pagerfanta/pagerfanta": "^2.6",


### PR DESCRIPTION
Fix test failures in the lowest dependency test run.