### PR TITLE
Support fetch entity in pager

### DIFF
--- a/src/Pagerfanta/AuraSqlPager.php
+++ b/src/Pagerfanta/AuraSqlPager.php
@@ -14,6 +14,12 @@ use Ray\AuraSqlModule\Exception\NotInitialized;
 // phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 use ReturnTypeWillChange;
 
+use function assert;
+use function class_exists;
+
+/**
+ * @template T
+ */
 class AuraSqlPager implements AuraSqlPagerInterface
 {
     private ViewInterface $view;
@@ -110,8 +116,12 @@ class AuraSqlPager implements AuraSqlPagerInterface
         throw new LogicException('read only');
     }
 
+    /**
+     * @return AdapterInterface<T>
+     */
     private function getPdoAdapter(): AdapterInterface
     {
+        assert($this->entity === null || class_exists($this->entity));
         $fetcher = $this->entity ? new FetchEntity($this->pdo, $this->entity) : new FetchAssoc($this->pdo);
 
         return new ExtendedPdoAdapter($this->pdo, $this->sql, $this->params, $fetcher);

--- a/src/Pagerfanta/AuraSqlPagerFactory.php
+++ b/src/Pagerfanta/AuraSqlPagerFactory.php
@@ -18,9 +18,9 @@ class AuraSqlPagerFactory implements AuraSqlPagerFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function newInstance(ExtendedPdoInterface $pdo, string $sql, array $params, int $paging, string $uriTemplate): AuraSqlPagerInterface
+    public function newInstance(ExtendedPdoInterface $pdo, string $sql, array $params, int $paging, string $uriTemplate, ?string $entity = null): AuraSqlPagerInterface
     {
-        $this->auraSqlPager->init($pdo, $sql, $params, $paging, new DefaultRouteGenerator($uriTemplate));
+        $this->auraSqlPager->init($pdo, $sql, $params, $paging, new DefaultRouteGenerator($uriTemplate), $entity);
 
         return $this->auraSqlPager;
     }

--- a/src/Pagerfanta/AuraSqlPagerFactoryInterface.php
+++ b/src/Pagerfanta/AuraSqlPagerFactoryInterface.php
@@ -11,5 +11,5 @@ interface AuraSqlPagerFactoryInterface
     /**
      * @param array<int|string|array<int|string>> $params
      */
-    public function newInstance(ExtendedPdoInterface $pdo, string $sql, array $params, int $paging, string $uriTemplate): AuraSqlPagerInterface;
+    public function newInstance(ExtendedPdoInterface $pdo, string $sql, array $params, int $paging, string $uriTemplate, ?string $entity = null): AuraSqlPagerInterface;
 }

--- a/src/Pagerfanta/AuraSqlPagerInterface.php
+++ b/src/Pagerfanta/AuraSqlPagerInterface.php
@@ -17,5 +17,5 @@ interface AuraSqlPagerInterface extends ArrayAccess
      * @param array<mixed> $params
      * @param int          $paging
      */
-    public function init(ExtendedPdoInterface $pdo, $sql, array $params, $paging, RouteGeneratorInterface $routeGenerator): void;
+    public function init(ExtendedPdoInterface $pdo, $sql, array $params, $paging, RouteGeneratorInterface $routeGenerator, ?string $entity = null): void;
 }

--- a/src/Pagerfanta/ExtendedPdoAdapter.php
+++ b/src/Pagerfanta/ExtendedPdoAdapter.php
@@ -6,8 +6,6 @@ namespace Ray\AuraSqlModule\Pagerfanta;
 
 use Aura\Sql\ExtendedPdoInterface;
 use Pagerfanta\Adapter\AdapterInterface;
-use PDO;
-
 use function assert;
 use function count;
 use function is_int;
@@ -17,7 +15,6 @@ use function preg_split;
 use function strpos;
 use function strtolower;
 use function trim;
-
 use const PHP_EOL;
 
 /**
@@ -31,15 +28,17 @@ class ExtendedPdoAdapter implements AdapterInterface
 
     /** @var array<mixed> */
     private array $params;
+    private FetcherInterface $fetcher;
 
     /**
      * @param array<mixed> $params
      */
-    public function __construct(ExtendedPdoInterface $pdo, string $sql, array $params)
+    public function __construct(ExtendedPdoInterface $pdo, string $sql, array $params, ?FetcherInterface $fetcher = null)
     {
         $this->pdo = $pdo;
         $this->sql = $sql;
         $this->params = $params;
+        $this->fetcher = $fetcher ?? new FetchAssoc($pdo);
     }
 
     /**
@@ -84,7 +83,7 @@ class ExtendedPdoAdapter implements AdapterInterface
     public function getSlice(int $offset, int $length): iterable
     {
         $sql = $this->sql . $this->getLimitClause($offset, $length);
-        $result = $this->pdo->perform($sql, $this->params)->fetchAll(PDO::FETCH_ASSOC);
+        $result = ($this->fetcher)($sql, $this->params);
 
         return ! $result ? [] : $result;
     }

--- a/src/Pagerfanta/ExtendedPdoAdapter.php
+++ b/src/Pagerfanta/ExtendedPdoAdapter.php
@@ -6,6 +6,7 @@ namespace Ray\AuraSqlModule\Pagerfanta;
 
 use Aura\Sql\ExtendedPdoInterface;
 use Pagerfanta\Adapter\AdapterInterface;
+
 use function assert;
 use function count;
 use function is_int;
@@ -15,6 +16,7 @@ use function preg_split;
 use function strpos;
 use function strtolower;
 use function trim;
+
 use const PHP_EOL;
 
 /**
@@ -78,7 +80,7 @@ class ExtendedPdoAdapter implements AdapterInterface
      * @param int $offset
      * @param int $length
      *
-     * @return array<array<mixed>>
+     * @return array<mixed>
      */
     public function getSlice(int $offset, int $length): iterable
     {

--- a/src/Pagerfanta/FetchAssoc.php
+++ b/src/Pagerfanta/FetchAssoc.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\AuraSqlModule\Pagerfanta;
+
+use Aura\Sql\ExtendedPdoInterface;
+use PDO;
+
+final class FetchAssoc implements FetcherInterface
+{
+    /** @var ExtendedPdoInterface */
+    private $pdo;
+
+    public function __construct(ExtendedPdoInterface $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function __invoke(string $sql, array $params): array
+    {
+        return $this->pdo->perform($sql, $params)->fetchAll(PDO::FETCH_ASSOC);
+    }
+}

--- a/src/Pagerfanta/FetchAssoc.php
+++ b/src/Pagerfanta/FetchAssoc.php
@@ -17,6 +17,9 @@ final class FetchAssoc implements FetcherInterface
         $this->pdo = $pdo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function __invoke(string $sql, array $params): array
     {
         return $this->pdo->perform($sql, $params)->fetchAll(PDO::FETCH_ASSOC);

--- a/src/Pagerfanta/FetchEntity.php
+++ b/src/Pagerfanta/FetchEntity.php
@@ -6,6 +6,7 @@ namespace Ray\AuraSqlModule\Pagerfanta;
 
 use Aura\Sql\ExtendedPdoInterface;
 use PDO;
+
 use function assert;
 use function class_exists;
 
@@ -25,7 +26,7 @@ class FetchEntity implements FetcherInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function __invoke(string $sql, array $params): array
     {

--- a/src/Pagerfanta/FetchEntity.php
+++ b/src/Pagerfanta/FetchEntity.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\AuraSqlModule\Pagerfanta;
+
+use Aura\Sql\ExtendedPdoInterface;
+use PDO;
+use function assert;
+use function class_exists;
+
+class FetchEntity implements FetcherInterface
+{
+    private ExtendedPdoInterface $pdo;
+    private string $entity;
+
+    /**
+     * @param class-string $entity
+     */
+    public function __construct(ExtendedPdoInterface $pdo, string $entity)
+    {
+        assert(class_exists($entity));
+        $this->pdo = $pdo;
+        $this->entity = $entity;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(string $sql, array $params): array
+    {
+        $pdoStatement = $this->pdo->perform($sql, $params);
+
+        return $pdoStatement->fetchAll(PDO::FETCH_FUNC, /** @param list<mixed> $args */function (...$args) {
+            /** @psalm-suppress MixedMethodCall */
+            return new $this->entity(...$args);
+        });
+    }
+}

--- a/src/Pagerfanta/FetcherInterface.php
+++ b/src/Pagerfanta/FetcherInterface.php
@@ -9,7 +9,7 @@ interface FetcherInterface
     /**
      * @param array<mixed> $params
      *
-     * @retrun array<mixed>
+     * @return array<mixed>
      */
     public function __invoke(string $sql, array $params): array;
 }

--- a/src/Pagerfanta/FetcherInterface.php
+++ b/src/Pagerfanta/FetcherInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\AuraSqlModule\Pagerfanta;
+
+interface FetcherInterface
+{
+    /**
+     * @param array<mixed> $params
+     *
+     * @retrun array<mixed>
+     */
+    public function __invoke(string $sql, array $params): array;
+}

--- a/tests/Fake/FakeEntity.php
+++ b/tests/Fake/FakeEntity.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Ray\AuraSqlModule;
+
+final class FakeEntity
+{
+    public string $id;
+    public string $name;
+    public string $post_content;
+
+    public function __construct(
+        string $id,
+        string $name,
+        string $post_content
+    ){
+        $this->id = $id;
+        $this->name = $name;
+        $this->post_content = $post_content;
+    }
+}

--- a/tests/Pagerfanta/AuraSqlPagerFactoryTest.php
+++ b/tests/Pagerfanta/AuraSqlPagerFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\AuraSqlModule\Pagerfanta;
 
 use Pagerfanta\View\DefaultView;
+use Ray\AuraSqlModule\FakeEntity;
 
 class AuraSqlPagerFactoryTest extends AbstractPdoTestCase
 {
@@ -16,11 +17,27 @@ class AuraSqlPagerFactoryTest extends AbstractPdoTestCase
         $this->factory = new AuraSqlPagerFactory(new AuraSqlPager(new DefaultView(), []));
     }
 
-    public function testNewInstance()
+    public function testNewInstance(): void
     {
         $pager = $this->factory->newInstance($this->pdo, 'SELECT * FROM posts', [], 1, '/{?page}');
         $this->assertInstanceOf(AuraSqlPager::class, $pager);
         $page = $pager[1];
+        $this->assertSame([
+            [
+                'id' => '1',
+                'username' => 'BEAR',
+                'post_content' => 'entry #1',
+            ],
+        ], $page->data);
         $this->assertInstanceOf(Page::class, $page);
+    }
+
+    public function testEntityPager(): void
+    {
+        $pager = $this->factory->newInstance($this->pdo, 'SELECT * FROM posts', [], 1, '/{?page}', FakeEntity::class);
+        $this->assertInstanceOf(AuraSqlPager::class, $pager);
+        $page = $pager[1];
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertInstanceOf(FakeEntity::class, $page->data[0]);
     }
 }

--- a/tests/Pagerfanta/PdoMySqlAdapterTest.php
+++ b/tests/Pagerfanta/PdoMySqlAdapterTest.php
@@ -15,12 +15,12 @@ class PdoMySqlAdapterTest extends AbstractPdoTestCase
         $this->adapter = new ExtendedPdoAdapter($this->pdo, $sql, []);
     }
 
-    public function testGetNbResults()
+    public function testGetNbResults(): void
     {
         $this->assertSame(50, $this->adapter->getNbResults());
     }
 
-    public function testGetResults()
+    public function testGetResults(): void
     {
         $expected = [
             [


### PR DESCRIPTION
Specifying an entity at the end of newInstance() in Pager will result in a result mapped to that entity.

PagerでnewInstance()の最後にエンティティを指定するとそのエンティティにマップされた結果が得られます。

example)

```diff
$pager = (new AuraSqlPagerFactory(new AuraSqlPager(new DefaultView(), [])));
-$pager->newInstance($this->pdo, 'SELECT * FROM posts', [], 1, '/{?page}'); // Assoc
+$pager->newInstance($this->pdo, 'SELECT * FROM posts', [], 1, '/{?page}', FakeEntity::class); // Entity
```
