### PR TITLE
Remove doctrine/annotations dependency for PHP 8.0-8.3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["7.4", "8.0", "8.1", "8.2"]'
+      old_stable: '["8.0", "8.1", "8.2"]'
       current_stable: 8.3

--- a/ANNOTATION_TO_ATTRIBUTE.md
+++ b/ANNOTATION_TO_ATTRIBUTE.md
@@ -1,0 +1,220 @@
+# Migrating from Doctrine Annotations to PHP 8 Attributes
+
+## Overview
+
+Ray.AuraSqlModule v2.x has removed the dependency on `doctrine/annotations` and now exclusively uses native PHP 8 attributes. This guide will help you migrate your application code from Doctrine annotations to PHP 8 attributes.
+
+## Why Migrate?
+
+- **doctrine/annotations is Abandoned**: The `doctrine/annotations` package has been officially abandoned by its maintainers. Continuing to use it poses security and compatibility risks as it will no longer receive updates or security patches.
+- **Native PHP Support**: PHP 8 attributes are a built-in language feature, providing first-class support without external dependencies
+- **Better Performance**: No runtime annotation parsing overhead - attributes are compiled and cached by PHP itself
+- **Modern Syntax**: Cleaner, more readable code that follows PHP 8+ best practices
+- **No Extra Dependencies**: Eliminates the need for the abandoned doctrine/annotations package
+- **Future-Proof**: Attributes are the official PHP standard for metadata, ensuring long-term compatibility
+
+## Migration Steps
+
+### Step 1: Update Ray.AuraSqlModule
+
+First, ensure you're using Ray.AuraSqlModule v2.x:
+
+```bash
+composer require ray/aura-sql-module:^2.0
+```
+
+### Step 2: Install Rector (if not already installed)
+
+Rector is an automated refactoring tool that can convert annotations to attributes:
+
+```bash
+composer require --dev rector/rector
+```
+
+### Step 3: Run Automated Migration
+
+Ray.AuraSqlModule provides a Rector configuration file for automated migration:
+
+```bash
+# Dry-run to preview changes
+vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php --dry-run
+
+# Apply the changes
+vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php
+```
+
+If you have tests that use annotations:
+
+```bash
+vendor/bin/rector process tests --config=vendor/ray/aura-sql-module/rector-migrate.php
+```
+
+### Step 4: Manual Review
+
+Review the changes made by Rector and adjust if necessary. Pay special attention to:
+
+- Multi-line annotations with complex values
+- Annotations with custom parameters
+- Import statements (Rector should handle these automatically)
+
+### Step 5: Remove doctrine/annotations
+
+After migration, you can safely remove the doctrine/annotations dependency:
+
+```bash
+composer remove doctrine/annotations
+```
+
+## Before and After Examples
+
+### Transactional Annotation
+
+**Before (Doctrine Annotation):**
+```php
+use Ray\AuraSqlModule\Annotation\Transactional;
+use Ray\AuraSqlModule\Annotation\WriteConnection;
+
+class UserRepository
+{
+    /**
+     * @WriteConnection
+     * @Transactional
+     */
+    public function save(User $user): void
+    {
+        // ...
+    }
+}
+```
+
+**After (PHP 8 Attribute):**
+```php
+use Ray\AuraSqlModule\Annotation\Transactional;
+use Ray\AuraSqlModule\Annotation\WriteConnection;
+
+class UserRepository
+{
+    #[WriteConnection, Transactional]
+    public function save(User $user): void
+    {
+        // ...
+    }
+}
+```
+
+### Read-Only Connection
+
+**Before (Doctrine Annotation):**
+```php
+use Aura\Sql\ExtendedPdoInterface;
+use Ray\AuraSqlModule\Annotation\ReadOnlyConnection;
+
+class UserFinder
+{
+    /**
+     * @ReadOnlyConnection
+     */
+    public function __construct(
+        private ExtendedPdoInterface $pdo
+    ) {}
+}
+```
+
+**After (PHP 8 Attribute):**
+```php
+use Aura\Sql\ExtendedPdoInterface;
+use Ray\AuraSqlModule\Annotation\ReadOnlyConnection;
+
+class UserFinder
+{
+    #[ReadOnlyConnection]
+    public function __construct(
+        private ExtendedPdoInterface $pdo
+    ) {}
+}
+```
+
+## Supported Annotations
+
+The following Ray.AuraSqlModule annotations are automatically converted:
+
+- `@Transactional` → `#[Transactional]`
+- `@WriteConnection` → `#[WriteConnection]`
+- `@ReadOnlyConnection` → `#[ReadOnlyConnection]`
+- `@Read` → `#[Read]`
+- `@AuraSql` → `#[AuraSql]`
+- `@EnvAuth` → `#[EnvAuth]`
+- `@HttpMethod` → `#[HttpMethod]`
+- `@PagerViewOption` → `#[PagerViewOption]`
+- `@AuraSqlQueryConfig` → `#[AuraSqlQueryConfig]`
+
+**Note**: This migration tool only handles Ray.AuraSqlModule annotations. For Ray.Di annotations (such as `@Inject`, `@Named`, etc.), please refer to the [Ray.Di migration guide](https://github.com/ray-di/Ray.Di).
+
+## Troubleshooting
+
+### Rector doesn't find annotations
+
+Make sure your code is using fully qualified class names in `use` statements:
+
+```php
+// Correct
+use Ray\AuraSqlModule\Annotation\Transactional;
+
+// Incorrect - Rector won't recognize this
+use Ray\AuraSqlModule\Annotation as DB;
+```
+
+### Import statements not updated
+
+Rector should automatically update import statements, but if it doesn't:
+
+1. Manually verify `use` statements are present
+2. Run your IDE's "Optimize Imports" feature
+3. Use tools like PHP-CS-Fixer to clean up unused imports
+
+### Complex annotation values
+
+For annotations with complex array values, you may need to manually adjust the syntax:
+
+**Before:**
+```php
+/**
+ * @Transactional({"pdo1", "pdo2"})
+ */
+```
+
+**After:**
+```php
+#[Transactional(["pdo1", "pdo2"])]
+```
+
+### Testing the migration
+
+After migration, ensure all tests pass:
+
+```bash
+vendor/bin/phpunit
+```
+
+## Manual Migration
+
+If you prefer not to use Rector, you can manually convert annotations:
+
+1. Replace `/** @AnnotationName */` with `#[AnnotationName]`
+2. Move attributes from docblocks to the line before the method/property/class
+3. For parameter annotations, place the attribute before the parameter type
+4. Ensure all necessary `use` statements are present
+
+## Need Help?
+
+If you encounter issues during migration:
+
+1. Check the [Ray.AuraSqlModule documentation](https://github.com/ray-di/Ray.AuraSqlModule)
+2. Review the [PHP 8 Attributes documentation](https://www.php.net/manual/en/language.attributes.php)
+3. [Open an issue](https://github.com/ray-di/Ray.AuraSqlModule/issues) on GitHub
+
+## References
+
+- [PHP 8 Attributes RFC](https://wiki.php.net/rfc/attributes_v2)
+- [Rector Documentation](https://github.com/rectorphp/rector)
+- [Ray.Di Documentation](https://ray-di.github.io/manuals/1.0/en/)

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "ray/di": "^2.13.1",
         "ray/aop": "^2.10.4",
         "aura/sql": "^4.0 || ^5.0",
-        "aura/sqlquery": "^2.7.1 || 3.x-dev",
+        "aura/sqlquery": "^2.7.1 || ^3.0",
         "pagerfanta/pagerfanta": "^3.5",
         "rize/uri-template": "^0.3.4 || ^0.4",
         "psr/log": "^1.1 || ^2.0 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "description": "aura/sql module for Ray.Di",
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-pdo": "*",
         "ray/di": "^2.13.1",
         "ray/aop": "^2.10.4",
@@ -16,7 +16,6 @@
         "aura/sqlquery": "^2.7.1 || 3.x-dev",
         "pagerfanta/pagerfanta": "^3.5",
         "rize/uri-template": "^0.3.4 || ^0.4",
-        "doctrine/annotations": "^1.11 || ^2.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "symfony/polyfill-php81": "^1.24"
     },

--- a/rector-migrate.php
+++ b/rector-migrate.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+
+/**
+ * Rector configuration for migrating from Doctrine Annotations to PHP 8 Attributes
+ *
+ * This configuration helps users migrate their code from doctrine/annotations
+ * to native PHP 8 attributes for Ray.AuraSqlModule annotations.
+ *
+ * Usage:
+ *   vendor/bin/rector process src --config=rector-migrate.php --dry-run
+ *   vendor/bin/rector process src --config=rector-migrate.php
+ */
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withConfiguredRule(
+        AnnotationToAttributeRector::class,
+        [
+            // Ray.AuraSqlModule Annotations
+            new AnnotationToAttribute('Ray\AuraSqlModule\Annotation\Transactional'),
+            new AnnotationToAttribute('Ray\AuraSqlModule\Annotation\WriteConnection'),
+            new AnnotationToAttribute('Ray\AuraSqlModule\Annotation\ReadOnlyConnection'),
+            new AnnotationToAttribute('Ray\AuraSqlModule\Annotation\Read'),
+            new AnnotationToAttribute('Ray\AuraSqlModule\Annotation\AuraSql'),
+            new AnnotationToAttribute('Ray\AuraSqlModule\Annotation\EnvAuth'),
+            new AnnotationToAttribute('Ray\AuraSqlModule\Annotation\HttpMethod'),
+            new AnnotationToAttribute('Ray\AuraSqlModule\Annotation\PagerViewOption'),
+            new AnnotationToAttribute('Ray\AuraSqlModule\Annotation\AuraSqlQueryConfig'),
+        ]
+    );

--- a/src/Annotation/AuraSql.php
+++ b/src/Annotation/AuraSql.php
@@ -6,10 +6,6 @@ namespace Ray\AuraSqlModule\Annotation;
 
 use Attribute;
 
-/**
- * @Annotation
- * @Target("CLASS")
- */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class AuraSql
 {

--- a/src/Annotation/AuraSqlQueryConfig.php
+++ b/src/Annotation/AuraSqlQueryConfig.php
@@ -5,15 +5,8 @@ declare(strict_types=1);
 namespace Ray\AuraSqlModule\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Ray\Di\Di\Qualifier;
 
-/**
- * @Annotation
- * @Target("METHOD")
- * @Qualifier
- * @NamedArgumentConstructor
- */
 #[Attribute(Attribute::TARGET_METHOD), Qualifier]
 final class AuraSqlQueryConfig
 {

--- a/src/Annotation/EnvAuth.php
+++ b/src/Annotation/EnvAuth.php
@@ -7,11 +7,6 @@ namespace Ray\AuraSqlModule\Annotation;
 use Attribute;
 use Ray\Di\Di\Qualifier;
 
-/**
- * @Annotation
- * @Target("METHOD")
- * @Qualifier
- */
 #[Attribute(Attribute::TARGET_METHOD), Qualifier]
 final class EnvAuth
 {

--- a/src/Annotation/HttpMethod.php
+++ b/src/Annotation/HttpMethod.php
@@ -6,10 +6,6 @@ namespace Ray\AuraSqlModule\Annotation;
 
 use Attribute;
 
-/**
- * @Annotation
- * @Target("METHOD")
- */
 #[Attribute(Attribute::TARGET_METHOD)]
 final class HttpMethod
 {

--- a/src/Annotation/PagerViewOption.php
+++ b/src/Annotation/PagerViewOption.php
@@ -5,23 +5,12 @@ declare(strict_types=1);
 namespace Ray\AuraSqlModule\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Ray\Di\Di\Qualifier;
 
-/**
- * @Annotation
- * @Target("METHOD")
- * @Qualifier
- * @NamedArgumentConstructor()
- */
 #[Attribute(Attribute::TARGET_METHOD), Qualifier]
 final class PagerViewOption
 {
-    /** @var string */
-    public $value;
-
-    public function __construct(string $value)
+    public function __construct(public string $value)
     {
-        $this->value = $value;
     }
 }

--- a/src/Annotation/Read.php
+++ b/src/Annotation/Read.php
@@ -5,23 +5,12 @@ declare(strict_types=1);
 namespace Ray\AuraSqlModule\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Ray\Di\Di\Qualifier;
 
-/**
- * @Annotation
- * @Target("METHOD")
- * @Qualifier
- * @NamedArgumentConstructor
- */
-#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+#[Attribute(Attribute::TARGET_METHOD|Attribute::TARGET_PARAMETER), Qualifier]
 final class Read
 {
-    /** @var string */
-    public $value;
-
-    public function __construct(string $value)
+    public function __construct(public string $value = '')
     {
-        $this->value = $value;
     }
 }

--- a/src/Annotation/ReadOnlyConnection.php
+++ b/src/Annotation/ReadOnlyConnection.php
@@ -6,10 +6,6 @@ namespace Ray\AuraSqlModule\Annotation;
 
 use Attribute;
 
-/**
- * @Annotation
- * @Target("METHOD")
- */
 #[Attribute(Attribute::TARGET_METHOD)]
 final class ReadOnlyConnection
 {

--- a/src/Annotation/Transactional.php
+++ b/src/Annotation/Transactional.php
@@ -5,27 +5,19 @@ declare(strict_types=1);
 namespace Ray\AuraSqlModule\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
-/**
- * @Annotation
- * @Target("METHOD")
- * @NamedArgumentConstructor()
- */
 #[Attribute(Attribute::TARGET_METHOD)]
 final class Transactional
 {
     /**
-     * @var ?array<string>
-     * @deprecated
-     */
-    public $value;
-
-    /**
      * @param array<string> $value
      */
-    public function __construct(array $value = ['pdo'])
+    public function __construct(
+        /**
+         * @deprecated
+         */
+        public array $value = ['pdo']
+    )
     {
-        $this->value = $value;
     }
 }

--- a/src/Annotation/WriteConnection.php
+++ b/src/Annotation/WriteConnection.php
@@ -6,10 +6,6 @@ namespace Ray\AuraSqlModule\Annotation;
 
 use Attribute;
 
-/**
- * @Annotation
- * @Target("METHOD")
- */
 #[Attribute(Attribute::TARGET_METHOD)]
 final class WriteConnection
 {

--- a/tests/Fake/FakeLogDb.php
+++ b/tests/Fake/FakeLogDb.php
@@ -4,15 +4,9 @@ namespace Ray\AuraSqlModule;
 
 use Attribute;
 use Aura\Sql\ExtendedPdoInterface;
-use Doctrine\Common\Annotations\Annotation\Target;
 use Ray\Di\Di\Named;
 use Ray\Di\Di\Qualifier;
 
-/**
- * @Annotation
- * @Target("METHOD")
- * @Qualifier()
- */
 #[Attribute(Attribute::TARGET_METHOD), Qualifier]
 final class FakeLogDb
 {

--- a/tests/Fake/FakeLogDbInject.php
+++ b/tests/Fake/FakeLogDbInject.php
@@ -4,17 +4,11 @@ namespace Ray\AuraSqlModule;
 
 use Attribute;
 use Aura\Sql\ExtendedPdoInterface;
-use Doctrine\Common\Annotations\Annotation\Target;
 use Ray\Di\Di\InjectInterface;
 use Ray\Di\Di\Named;
 use Ray\Di\Di\Qualifier;
 use Ray\Di\InjectorInterface;
 
-/**
- * @Annotation
- * @Target("METHOD")
- * @Qualifier()
- */
 #[Attribute(Attribute::TARGET_METHOD), Qualifier]
 final class FakeLogDbInject implements InjectInterface
 {


### PR DESCRIPTION
## Summary

Remove the dependency on the abandoned `doctrine/annotations` package for PHP 8.0-8.3 users.

This is the backport of #78 for users who cannot upgrade to PHP 8.4 yet.

## Changes

### 1. Remove doctrine/annotations dependency
- Remove `doctrine/annotations` from composer.json
- Remove Doctrine annotation imports from all annotation classes
- Remove `@Annotation`, `@Target`, and `@NamedArgumentConstructor` docblock comments
- Update test fake classes to remove Doctrine references
- Set PHP requirement to `^8.0` (supports PHP 8.0, 8.1, 8.2, 8.3)

### 2. Add annotation to attribute migration support
- Add `rector-migrate.php`: Rector configuration for automated migration
- Add `ANNOTATION_TO_ATTRIBUTE.md`: Comprehensive migration guide

## Why This Change?

The `doctrine/annotations` package has been officially **abandoned** by its maintainers and will no longer receive updates or security patches.

This change allows PHP 8.0-8.3 users to:
- Eliminate security and compatibility risks from the abandoned package
- Adopt native PHP 8 attributes (available since PHP 8.0)
- Improve performance (no runtime annotation parsing overhead)

## Target Release

1.13.4

## Migration Support

Users can migrate their applications using the provided tools:

```bash
# Preview changes
vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php --dry-run

# Apply migration
vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php
```

See `ANNOTATION_TO_ATTRIBUTE.md` for detailed migration guide.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the abandoned doctrine/annotations package for PHP 8.0–8.3, refactor all annotations to native PHP 8 attributes, update composer requirements, and add tooling and documentation to assist in migrating existing annotation usage.

New Features:
- Add Rector configuration for automated annotation-to-attribute migration
- Provide a detailed migration guide in ANNOTATION_TO_ATTRIBUTE.md

Enhancements:
- Remove doctrine/annotations dependency and strip related docblock comments
- Refactor annotation classes to use native PHP 8 attributes instead of Doctrine annotations
- Raise minimum PHP requirement to ^8.0 (drop support for PHP 7.4)

Documentation:
- Add comprehensive migration documentation for transitioning annotations to attributes

Tests:
- Update fake test classes to remove Doctrine annotation references and use attributes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive migration guide for moving from Doctrine annotations to PHP 8 attributes.

* **Chores**
  * Raised minimum PHP requirement to 8.0.
  * Removed legacy annotations dependency.
  * Added automated migration tooling/config to assist attribute conversion.
  * Updated CI to stop testing PHP 7.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->