### PR TITLE
Remove remaining Doctrine annotation syntax from docblocks

### DIFF
--- a/rector-migrate.php
+++ b/rector-migrate.php
@@ -13,14 +13,10 @@ use Rector\Php80\ValueObject\AnnotationToAttribute;
  * to native PHP 8 attributes for Ray.AuraSqlModule annotations.
  *
  * Usage:
- *   vendor/bin/rector process src --config=rector-migrate.php --dry-run
- *   vendor/bin/rector process src --config=rector-migrate.php
+ *   vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php --dry-run
+ *   vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php
  */
 return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-    ])
     ->withConfiguredRule(
         AnnotationToAttributeRector::class,
         [

--- a/rector-migrate.php
+++ b/rector-migrate.php
@@ -13,8 +13,12 @@ use Rector\Php80\ValueObject\AnnotationToAttribute;
  * to native PHP 8 attributes for Ray.AuraSqlModule annotations.
  *
  * Usage:
+ *   # Process a single directory
  *   vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php --dry-run
  *   vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php
+ *
+ *   # Process multiple directories
+ *   vendor/bin/rector process src tests --config=vendor/ray/aura-sql-module/rector-migrate.php
  */
 return RectorConfig::configure()
     ->withConfiguredRule(

--- a/src/AuraSqlQueryDeleteProvider.php
+++ b/src/AuraSqlQueryDeleteProvider.php
@@ -13,11 +13,7 @@ use Ray\Di\ProviderInterface;
 /** @implements ProviderInterface<DeleteInterface> */
 final readonly class AuraSqlQueryDeleteProvider implements ProviderInterface
 {
-    /**
-     * @param string $db The database type
-     *
-     * @AuraSqlQueryConfig
-     */
+    /** @param string $db The database type */
     #[AuraSqlQueryConfig]
     public function __construct(private string $db)
     {

--- a/src/AuraSqlQueryInsertProvider.php
+++ b/src/AuraSqlQueryInsertProvider.php
@@ -13,11 +13,7 @@ use Ray\Di\ProviderInterface;
 /** @implements ProviderInterface<InsertInterface> */
 final readonly class AuraSqlQueryInsertProvider implements ProviderInterface
 {
-    /**
-     * @param string $db The database type
-     *
-     * @AuraSqlQueryConfig
-     */
+    /** @param string $db The database type */
     #[AuraSqlQueryConfig]
     public function __construct(private string $db)
     {

--- a/src/AuraSqlQuerySelectProvider.php
+++ b/src/AuraSqlQuerySelectProvider.php
@@ -13,11 +13,7 @@ use Ray\Di\ProviderInterface;
 /** @implements ProviderInterface<SelectInterface> */
 final readonly class AuraSqlQuerySelectProvider implements ProviderInterface
 {
-    /**
-     * @param string $db The database type
-     *
-     * @AuraSqlQueryConfig
-     */
+    /** @param string $db The database type */
     #[AuraSqlQueryConfig]
     public function __construct(private string $db)
     {

--- a/src/AuraSqlQueryUpdateProvider.php
+++ b/src/AuraSqlQueryUpdateProvider.php
@@ -13,11 +13,7 @@ use Ray\Di\ProviderInterface;
 /** @implements ProviderInterface<UpdateInterface> */
 final readonly class AuraSqlQueryUpdateProvider implements ProviderInterface
 {
-    /**
-     * @param string $db The database type
-     *
-     * @AuraSqlQueryConfig
-     */
+    /** @param string $db The database type */
     #[AuraSqlQueryConfig]
     public function __construct(private string $db)
     {

--- a/src/Pagerfanta/AuraSqlPager.php
+++ b/src/Pagerfanta/AuraSqlPager.php
@@ -31,11 +31,7 @@ final class AuraSqlPager implements AuraSqlPagerInterface
     /** @phpstan-var positive-int */
     private int $paging;
 
-    /**
-     * @param array<string, mixed> $viewOptions
-     *
-     * @PagerViewOption("viewOptions")
-     */
+    /** @param array<string, mixed> $viewOptions */
     #[PagerViewOption('viewOptions')]
     public function __construct(private readonly ViewInterface $view, private readonly array $viewOptions)
     {

--- a/src/Pagerfanta/AuraSqlQueryPager.php
+++ b/src/Pagerfanta/AuraSqlQueryPager.php
@@ -28,11 +28,7 @@ final class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, ArrayAccess
     /** @phpstan-var positive-int */
     private int $paging;
 
-    /**
-     * @param array<string, mixed> $viewOptions
-     *
-     * @PagerViewOption("viewOptions")
-     */
+    /** @param array<string, mixed> $viewOptions */
     #[PagerViewOption('viewOptions')]
     public function __construct(private readonly ViewInterface $view, private readonly array $viewOptions)
     {

--- a/tests/Fake/FakeModel.php
+++ b/tests/Fake/FakeModel.php
@@ -8,9 +8,6 @@ use Ray\AuraSqlModule\Annotation\ReadOnlyConnection;
 use Ray\AuraSqlModule\Annotation\Transactional;
 use Ray\AuraSqlModule\Annotation\WriteConnection;
 
-/**
- * @AuraSql
- */
 #[AuraSql]
 class FakeModel
 {
@@ -34,38 +31,24 @@ class FakeModel
         return true;
     }
 
-    /**
-     * @ReadOnlyConnection
-     */
     #[ReadOnlyConnection]
     public function slave()
     {
         return true;
     }
 
-    /**
-     * @WriteConnection
-     * @Transactional
-     */
     #[WriteConnection, Transactional]
     public function master()
     {
         return true;
     }
 
-    /**
-     * @WriteConnection
-     * @Transactional
-     */
     #[WriteConnection, Transactional]
     public function dbError()
     {
         $this->pdo->exec('xxx');
     }
 
-    /**
-     * @Transactional
-     */
     #[Transactional]
     public function noDb()
     {

--- a/tests/Fake/FakeMultiDb.php
+++ b/tests/Fake/FakeMultiDb.php
@@ -16,9 +16,6 @@ class FakeMultiDb
     protected $pdo2;
     protected $pdo3;
 
-    /**
-     * @Named("pdo1=pdo1,pdo2=pdo2,pdo3=pdo3")
-     */
     #[Named('pdo1=pdo1,pdo2=pdo2,pdo3=pdo3')]
     public function __construct(ExtendedPdoInterface $pdo1, ExtendedPdoInterface $pdo2, ExtendedPdoInterface $pdo3)
     {
@@ -30,9 +27,6 @@ class FakeMultiDb
         $this->pdo3->exec('CREATE TABLE user(name, age)');
     }
 
-    /**
-     * @Transactional({"pdo1","pdo2","pdo3"})
-     */
     #[Transactional(['pdo1', 'pdo2', 'pdo3'])]
     public function write()
     {
@@ -54,9 +48,6 @@ class FakeMultiDb
         return $users;
     }
 
-    /**
-     * @Transactional()
-     */
     #[Transactional]
     public function writeNoValueTransactional()
     {

--- a/tests/Fake/FakeQueryInject.php
+++ b/tests/Fake/FakeQueryInject.php
@@ -11,11 +11,7 @@ class FakeQueryInject
     use AuraSqlUpdateInject;
     use AuraSqlDeleteInject;
 
-    /**
-     * @AuraSqlQueryConfig
-     *
-     * @param string $db
-     */
+    /** @param string $db */
     #[AuraSqlQueryConfig]
     public function __construct(private string $db)
     {


### PR DESCRIPTION
## Summary
This PR removes remaining Doctrine annotation syntax from docblocks in both src/ and tests/ directories.

## Problem
When testing the migration guide (ANNOTATION_TO_ATTRIBUTE.md), we discovered that Doctrine annotation syntax remained in docblocks:
- `@PagerViewOption("viewOptions")` in pager classes
- `@AuraSqlQueryConfig` in query provider classes  
- Various annotations in test Fake classes

These caused the following error when doctrine/annotations was present:
```
[Semantical Error] The class "Ray\AuraSqlModule\Annotation\AuraSqlQueryConfig" is not annotated with @Annotation.
```

## Changes
Removed old `@Annotation` syntax from docblocks in 9 files:

**Source files:**
- src/Pagerfanta/AuraSqlPager.php
- src/Pagerfanta/AuraSqlQueryPager.php
- src/AuraSqlQueryInsertProvider.php
- src/AuraSqlQuerySelectProvider.php
- src/AuraSqlQueryUpdateProvider.php
- src/AuraSqlQueryDeleteProvider.php

**Test files:**
- tests/Fake/FakeModel.php
- tests/Fake/FakeMultiDb.php
- tests/Fake/FakeQueryInject.php

## Testing
✅ All 75 tests passing
✅ Migration guide tested successfully with no Doctrine annotation conflicts
✅ Rector correctly converts annotations to attributes
✅ PHP reflection API recognizes attributes
✅ Ray.Di recognizes attributes correctly

This fix ensures users can successfully migrate following ANNOTATION_TO_ATTRIBUTE.md without encountering Doctrine annotation conflicts.

## Summary by Sourcery

Remove all legacy Doctrine annotation comments from src/ and tests/ directories and consistently use PHP attributes to avoid annotation conflicts during migration.

Bug Fixes:
- Remove unsupported Doctrine annotations from docblocks to prevent semantical errors when doctrine/annotations is present

Enhancements:
- Replace remaining Doctrine annotation syntax in docblocks with native PHP attributes in source and test files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized and modernized annotation and documentation formatting across code and tests, migrating legacy docblock annotations to modern attribute-style metadata. No functional changes to behavior, APIs, or public method signatures; this is purely internal cleanup to improve maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->