### PR TITLE
Fix rector-migrate.php for 1.13.x: Remove withPaths() to allow users to specify target paths

### DIFF
--- a/rector-migrate.php
+++ b/rector-migrate.php
@@ -13,14 +13,14 @@ use Rector\Php80\ValueObject\AnnotationToAttribute;
  * to native PHP 8 attributes for Ray.AuraSqlModule annotations.
  *
  * Usage:
- *   vendor/bin/rector process src --config=rector-migrate.php --dry-run
- *   vendor/bin/rector process src --config=rector-migrate.php
+ *   # Process a single directory
+ *   vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php --dry-run
+ *   vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php
+ *
+ *   # Process multiple directories
+ *   vendor/bin/rector process src tests --config=vendor/ray/aura-sql-module/rector-migrate.php
  */
 return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-    ])
     ->withConfiguredRule(
         AnnotationToAttributeRector::class,
         [


### PR DESCRIPTION
## Summary
Backport of the rector-migrate.php fix from 1.16.0 to the 1.13.x branch (PHP 8.0-8.3).

## Problem
The rector-migrate.php file is installed in `vendor/ray/aura-sql-module/`, so `__DIR__` points to the package directory, not the user's project. This prevented the migration tool from scanning user code.

## Changes
- Removed `withPaths([__DIR__ . '/src', __DIR__ . '/tests'])` 
- Users now specify paths via command line arguments
- Updated usage examples to show correct vendor/ path
- Added example for processing multiple directories

## Usage (After Fix)
```bash
# Process a single directory
vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php --dry-run
vendor/bin/rector process src --config=vendor/ray/aura-sql-module/rector-migrate.php

# Process multiple directories
vendor/bin/rector process src tests --config=vendor/ray/aura-sql-module/rector-migrate.php
```

## Testing
✅ Same fix as 1.16.0 (verified working)
✅ Matches pattern used in Ray.PsrCacheModule (PR #32)

## Related
- 1.x branch fix: #83 (merged into 1.16.0)
- Ray.PsrCacheModule: PR #32

This is a **critical fix** for PHP 8.0-8.3 users who want to migrate from annotations to attributes.

## Summary by Sourcery

Backport the rector-migrate.php fix to the 1.13.x branch by removing withPaths configuration so users can specify target paths via command line and updating usage examples accordingly

Bug Fixes:
- Remove hardcoded paths in rector-migrate.php to enable scanning of user-specified directories

Enhancements:
- Update usage examples to reference the correct vendor path
- Add examples for processing multiple directories via CLI

Documentation:
- Revise documentation comments in rector-migrate.php for single and multi-directory usage