### PR TITLE
Remove all remaining docblock annotations

### DIFF
--- a/src/AuraSqlConnectionInterceptor.php
+++ b/src/AuraSqlConnectionInterceptor.php
@@ -22,11 +22,7 @@ class AuraSqlConnectionInterceptor implements MethodInterceptor
     /** @var string[] */
     private array $readsMethods = [];
 
-    /**
-     * @phpstan-param array<string> $readMethods
-     *
-     * @Read("readMethods")
-     */
+    /** @phpstan-param array<string> $readMethods */
     #[Read('readMethods')]
     public function __construct(ConnectionLocatorInterface $connectionLocator, array $readMethods)
     {

--- a/src/AuraSqlDeleteInject.php
+++ b/src/AuraSqlDeleteInject.php
@@ -12,7 +12,6 @@ trait AuraSqlDeleteInject
     /** @var DeleteInterface */
     protected $delete;
 
-    /** @Inject */
     #[Inject]
     public function setAuraSqlDelete(DeleteInterface $delete): void
     {

--- a/src/AuraSqlInject.php
+++ b/src/AuraSqlInject.php
@@ -13,7 +13,6 @@ trait AuraSqlInject
     /** @var ExtendedPdoInterface */
     protected $pdo;
 
-    /** @Inject() */
     #[Inject]
     public function setAuraSql(?ExtendedPdoInterface $pdo)
     {

--- a/src/AuraSqlInsertInject.php
+++ b/src/AuraSqlInsertInject.php
@@ -12,7 +12,6 @@ trait AuraSqlInsertInject
     /** @var InsertInterface */
     protected $insert;
 
-    /** @Inject */
     #[Inject]
     public function setAuraSqlInsert(InsertInterface $insert): void
     {

--- a/src/AuraSqlPagerInject.php
+++ b/src/AuraSqlPagerInject.php
@@ -12,7 +12,6 @@ trait AuraSqlPagerInject
     /** @var AuraSqlPagerFactoryInterface */
     protected $pagerFactory;
 
-    /** @Inject */
     #[Inject]
     public function setAuraSqlPager(AuraSqlPagerFactoryInterface $pagerFactory): void
     {

--- a/src/AuraSqlQueryDeleteProvider.php
+++ b/src/AuraSqlQueryDeleteProvider.php
@@ -14,11 +14,7 @@ class AuraSqlQueryDeleteProvider implements ProviderInterface
 {
     private string $db;
 
-    /**
-     * @param string $db The database type
-     *
-     * @AuraSqlQueryConfig
-     */
+    /** @param string $db The database type */
     #[AuraSqlQueryConfig]
     public function __construct(string $db)
     {

--- a/src/AuraSqlQueryInsertProvider.php
+++ b/src/AuraSqlQueryInsertProvider.php
@@ -14,11 +14,7 @@ class AuraSqlQueryInsertProvider implements ProviderInterface
 {
     private string $db;
 
-    /**
-     * @param string $db The database type
-     *
-     * @AuraSqlQueryConfig
-     */
+    /** @param string $db The database type */
     #[AuraSqlQueryConfig]
     public function __construct(string $db)
     {

--- a/src/AuraSqlQueryPagerInject.php
+++ b/src/AuraSqlQueryPagerInject.php
@@ -12,7 +12,6 @@ trait AuraSqlQueryPagerInject
     /** @var AuraSqlQueryPagerFactoryInterface */
     protected $queryPagerFactory;
 
-    /** @Inject */
     #[Inject]
     public function setAuraSqlQueryPager(AuraSqlQueryPagerFactoryInterface $queryPagerFactory): void
     {

--- a/src/AuraSqlQuerySelectProvider.php
+++ b/src/AuraSqlQuerySelectProvider.php
@@ -14,11 +14,7 @@ class AuraSqlQuerySelectProvider implements ProviderInterface
 {
     private string $db;
 
-    /**
-     * @param string $db The database type
-     *
-     * @AuraSqlQueryConfig
-     */
+    /** @param string $db The database type */
     #[AuraSqlQueryConfig()]
     public function __construct($db)
     {

--- a/src/AuraSqlQueryUpdateProvider.php
+++ b/src/AuraSqlQueryUpdateProvider.php
@@ -14,11 +14,7 @@ class AuraSqlQueryUpdateProvider implements ProviderInterface
 {
     private string $db;
 
-    /**
-     * @param string $db The database type
-     *
-     * @AuraSqlQueryConfig
-     */
+    /** @param string $db The database type */
     #[AuraSqlQueryConfig]
     public function __construct($db)
     {

--- a/src/AuraSqlSelectInject.php
+++ b/src/AuraSqlSelectInject.php
@@ -12,7 +12,6 @@ trait AuraSqlSelectInject
     /** @var SelectInterface */
     protected $select;
 
-    /** @Inject */
     #[Inject]
     public function setAuraSqlSelect(SelectInterface $select): void
     {

--- a/src/AuraSqlUpdateInject.php
+++ b/src/AuraSqlUpdateInject.php
@@ -12,7 +12,6 @@ trait AuraSqlUpdateInject
     /** @var UpdateInterface */
     protected $update;
 
-    /** @Inject */
     #[Inject]
     public function setAuraSqlUpdate(UpdateInterface $update): void
     {

--- a/src/Pagerfanta/AuraSqlPager.php
+++ b/src/Pagerfanta/AuraSqlPager.php
@@ -35,11 +35,7 @@ class AuraSqlPager implements AuraSqlPagerInterface
     /** @phpstan-var positive-int */
     private int $paging;
 
-    /**
-     * @param array<array<string>> $viewOptions
-     *
-     * @PagerViewOption("viewOptions")
-     */
+    /** @param array<array<string>> $viewOptions */
     #[PagerViewOption('viewOptions')]
     public function __construct(ViewInterface $view, array $viewOptions)
     {

--- a/src/Pagerfanta/AuraSqlQueryPager.php
+++ b/src/Pagerfanta/AuraSqlQueryPager.php
@@ -31,11 +31,7 @@ class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, ArrayAccess
     /** @phpstan-var positive-int */
     private int $paging;
 
-    /**
-     * @param array<array<string>> $viewOptions
-     *
-     * @PagerViewOption("viewOptions")
-     */
+    /** @param array<array<string>> $viewOptions */
     #[PagerViewOption('viewOptions')]
     public function __construct(ViewInterface $view, array $viewOptions)
     {

--- a/tests/Fake/FakeModel.php
+++ b/tests/Fake/FakeModel.php
@@ -8,9 +8,6 @@ use Ray\AuraSqlModule\Annotation\ReadOnlyConnection;
 use Ray\AuraSqlModule\Annotation\Transactional;
 use Ray\AuraSqlModule\Annotation\WriteConnection;
 
-/**
- * @AuraSql
- */
 #[AuraSql]
 class FakeModel
 {
@@ -34,38 +31,24 @@ class FakeModel
         return true;
     }
 
-    /**
-     * @ReadOnlyConnection
-     */
     #[ReadOnlyConnection]
     public function slave()
     {
         return true;
     }
 
-    /**
-     * @WriteConnection
-     * @Transactional
-     */
     #[WriteConnection, Transactional]
     public function master()
     {
         return true;
     }
 
-    /**
-     * @WriteConnection
-     * @Transactional
-     */
     #[WriteConnection, Transactional]
     public function dbError()
     {
         $this->pdo->exec('xxx');
     }
 
-    /**
-     * @Transactional
-     */
     #[Transactional]
     public function noDb()
     {

--- a/tests/Fake/FakeMultiDb.php
+++ b/tests/Fake/FakeMultiDb.php
@@ -16,9 +16,6 @@ class FakeMultiDb
     protected $pdo2;
     protected $pdo3;
 
-    /**
-     * @Named("pdo1=pdo1,pdo2=pdo2,pdo3=pdo3")
-     */
     #[Named('pdo1=pdo1,pdo2=pdo2,pdo3=pdo3')]
     public function __construct(ExtendedPdoInterface $pdo1, ExtendedPdoInterface $pdo2, ExtendedPdoInterface $pdo3)
     {
@@ -30,9 +27,6 @@ class FakeMultiDb
         $this->pdo3->exec('CREATE TABLE user(name, age)');
     }
 
-    /**
-     * @Transactional({"pdo1","pdo2","pdo3"})
-     */
     #[Transactional(['pdo1', 'pdo2', 'pdo3'])]
     public function write()
     {
@@ -54,9 +48,6 @@ class FakeMultiDb
         return $users;
     }
 
-    /**
-     * @Transactional()
-     */
     #[Transactional]
     public function writeNoValueTransactional()
     {

--- a/tests/Fake/FakeName.php
+++ b/tests/Fake/FakeName.php
@@ -12,28 +12,18 @@ class FakeName
     public $pdoAnno;
     public $pdoSetterInject;
 
-    /**
-     * @Named("log_db")
-     */
     #[Named('log_db')]
     public function __construct(ExtendedPdoInterface $pdo)
     {
         $this->pdo = $pdo;
     }
 
-    /**
-     * @Inject
-     * @FakeLogDb
-     */
     #[Inject, FakeLogDb]
     public function setFakeDb(ExtendedPdoInterface $pdo)
     {
         $this->pdoAnno = $pdo;
     }
 
-    /**
-     * @FakeLogDbInject
-     */
     #[FakeLogDbInject]
     public function setFakeDbWithInjectAnnotation(ExtendedPdoInterface $pdo)
     {

--- a/tests/Fake/FakeQueryInject.php
+++ b/tests/Fake/FakeQueryInject.php
@@ -13,11 +13,7 @@ class FakeQueryInject
 
     private string $db;
 
-    /**
-     * @AuraSqlQueryConfig
-     *
-     * @param string $db
-     */
+    /** @param string $db */
     #[AuraSqlQueryConfig]
     public function __construct($db)
     {


### PR DESCRIPTION
## Summary
Complete the migration from Doctrine annotations to PHP 8 Attributes by removing all remaining docblock annotations.

## Changes
- Removed `@Inject` from 7 inject trait files
- Removed `@PagerViewOption` from 2 pager files  
- Removed `@AuraSqlQueryConfig` from 4 query provider files
- Removed `@Read` from AuraSqlConnectionInterceptor
- Removed various annotations from test fake classes (`@AuraSql`, `@Transactional`, `@ReadOnlyConnection`, `@WriteConnection`, `@Named`, etc.)

## Details
18 files modified, 83 lines removed

This completes the migration that was started in previous releases. All DI and AOP configurations now use PHP 8 Attributes exclusively.

## Test plan
- Ran `composer cs-fix` - passed
- Ran `composer test` - existing test failures are unrelated to this change
- Verified no docblock annotations remain in src/ and tests/ directories

## Summary by Sourcery

Enhancements:
- Remove all remaining docblock annotations (e.g., @Inject, @AuraSqlQueryConfig, @PagerViewOption, @Read) and replace them with PHP 8 attributes across source and test files.