### PR TITLE
Migrate to parameter-level attributes for Ray.Di 2.19.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^12.1",
-        "bamarni/composer-bin-plugin": "^1.4"
+        "bamarni/composer-bin-plugin": "^1.4",
+        "ray/compiler": "^1.13"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     "require": {
         "php": "^8.4",
         "ext-pdo": "*",
-        "ray/di": "^2.18",
-        "ray/aop": "^2.17",
+        "ray/di": "^2.19.1",
+        "ray/aop": "^2.19",
         "aura/sql": "^6.0",
         "pagerfanta/pagerfanta": "^3.5 || ^4.7",
         "rize/uri-template": "^0.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,13 +9,6 @@
     </include>
   </source>
 
-  <coverage>
-    <report>
-      <html outputDirectory="coverage-html"/>
-      <text outputFile="php://stdout"/>
-    </report>
-  </coverage>
-
   <testsuites>
     <testsuite name="all">
       <directory>tests</directory>

--- a/src/Annotation/AuraSqlQueryConfig.php
+++ b/src/Annotation/AuraSqlQueryConfig.php
@@ -7,11 +7,11 @@ namespace Ray\AuraSqlModule\Annotation;
 use Attribute;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+#[Attribute(Attribute::TARGET_PARAMETER), Qualifier]
 final class AuraSqlQueryConfig
 {
     /**
-     * @param array<string, string> $value
+     * @param array<string, string>|null $value
      */
     public function __construct(public ?array $value = null)
     {

--- a/src/Annotation/EnvAuth.php
+++ b/src/Annotation/EnvAuth.php
@@ -7,7 +7,7 @@ namespace Ray\AuraSqlModule\Annotation;
 use Attribute;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+#[Attribute(Attribute::TARGET_PARAMETER), Qualifier]
 final class EnvAuth
 {
 }

--- a/src/Annotation/PagerViewOption.php
+++ b/src/Annotation/PagerViewOption.php
@@ -7,10 +7,10 @@ namespace Ray\AuraSqlModule\Annotation;
 use Attribute;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+#[Attribute(Attribute::TARGET_PARAMETER), Qualifier]
 final class PagerViewOption
 {
-    public function __construct(public string $value)
+    public function __construct(public string $value = '')
     {
     }
 }

--- a/src/AuraSqlMasterModule.php
+++ b/src/AuraSqlMasterModule.php
@@ -39,7 +39,13 @@ final class AuraSqlMasterModule extends AbstractModule
     {
         $this->bind(ExtendedPdoInterface::class)->toConstructor(
             ExtendedPdo::class,
-            'dsn=pdo_dsn,username=pdo_user,password=pdo_pass,options=pdo_option,attributes=pdo_attributes',
+            [
+                'dsn' => 'pdo_dsn',
+                'username' => 'pdo_user',
+                'password' => 'pdo_pass',
+                'options' => 'pdo_option',
+                'attributes' => 'pdo_attributes',
+            ],
         )->in(Scope::SINGLETON);
         $this->bind()->annotatedWith('pdo_dsn')->toInstance($this->dsn);
         $this->bind()->annotatedWith('pdo_user')->toInstance($this->user);

--- a/src/AuraSqlModule.php
+++ b/src/AuraSqlModule.php
@@ -57,7 +57,13 @@ final class AuraSqlModule extends AbstractModule
         $this->bind()->annotatedWith('pdo_queries')->toInstance($this->queries);
         $this->bind(ExtendedPdoInterface::class)->toConstructor(
             ExtendedPdo::class,
-            'dsn=pdo_dsn,username=pdo_user,password=pdo_pass,options=pdo_options,queries=pdo_queries',
+            [
+                'dsn' => 'pdo_dsn',
+                'username' => 'pdo_user',
+                'password' => 'pdo_pass',
+                'options' => 'pdo_options',
+                'queries' => 'pdo_queries',
+            ],
         )->in(Scope::SINGLETON);
     }
 

--- a/src/AuraSqlQueryDeleteProvider.php
+++ b/src/AuraSqlQueryDeleteProvider.php
@@ -14,8 +14,8 @@ use Ray\Di\ProviderInterface;
 final readonly class AuraSqlQueryDeleteProvider implements ProviderInterface
 {
     /** @param string $db The database type */
-    #[AuraSqlQueryConfig]
-    public function __construct(private string $db)
+    public function __construct(#[AuraSqlQueryConfig]
+    private string $db)
     {
     }
 

--- a/src/AuraSqlQueryDeleteProvider.php
+++ b/src/AuraSqlQueryDeleteProvider.php
@@ -14,9 +14,10 @@ use Ray\Di\ProviderInterface;
 final readonly class AuraSqlQueryDeleteProvider implements ProviderInterface
 {
     /** @param string $db The database type */
-    public function __construct(#[AuraSqlQueryConfig]
-    private string $db)
-    {
+    public function __construct(
+        #[AuraSqlQueryConfig]
+        private string $db
+    ) {
     }
 
     /**

--- a/src/AuraSqlQueryInsertProvider.php
+++ b/src/AuraSqlQueryInsertProvider.php
@@ -14,8 +14,8 @@ use Ray\Di\ProviderInterface;
 final readonly class AuraSqlQueryInsertProvider implements ProviderInterface
 {
     /** @param string $db The database type */
-    #[AuraSqlQueryConfig]
-    public function __construct(private string $db)
+    public function __construct(#[AuraSqlQueryConfig]
+    private string $db)
     {
     }
 

--- a/src/AuraSqlQueryInsertProvider.php
+++ b/src/AuraSqlQueryInsertProvider.php
@@ -14,9 +14,10 @@ use Ray\Di\ProviderInterface;
 final readonly class AuraSqlQueryInsertProvider implements ProviderInterface
 {
     /** @param string $db The database type */
-    public function __construct(#[AuraSqlQueryConfig]
-    private string $db)
-    {
+    public function __construct(
+        #[AuraSqlQueryConfig]
+        private string $db
+    ) {
     }
 
     /**

--- a/src/AuraSqlQuerySelectProvider.php
+++ b/src/AuraSqlQuerySelectProvider.php
@@ -14,8 +14,8 @@ use Ray\Di\ProviderInterface;
 final readonly class AuraSqlQuerySelectProvider implements ProviderInterface
 {
     /** @param string $db The database type */
-    #[AuraSqlQueryConfig]
-    public function __construct(private string $db)
+    public function __construct(#[AuraSqlQueryConfig]
+    private string $db)
     {
     }
 

--- a/src/AuraSqlQuerySelectProvider.php
+++ b/src/AuraSqlQuerySelectProvider.php
@@ -14,9 +14,10 @@ use Ray\Di\ProviderInterface;
 final readonly class AuraSqlQuerySelectProvider implements ProviderInterface
 {
     /** @param string $db The database type */
-    public function __construct(#[AuraSqlQueryConfig]
-    private string $db)
-    {
+    public function __construct(
+        #[AuraSqlQueryConfig]
+        private string $db
+    ) {
     }
 
     /**

--- a/src/AuraSqlQueryUpdateProvider.php
+++ b/src/AuraSqlQueryUpdateProvider.php
@@ -14,8 +14,8 @@ use Ray\Di\ProviderInterface;
 final readonly class AuraSqlQueryUpdateProvider implements ProviderInterface
 {
     /** @param string $db The database type */
-    #[AuraSqlQueryConfig]
-    public function __construct(private string $db)
+    public function __construct(#[AuraSqlQueryConfig]
+    private string $db)
     {
     }
 

--- a/src/AuraSqlQueryUpdateProvider.php
+++ b/src/AuraSqlQueryUpdateProvider.php
@@ -14,9 +14,10 @@ use Ray\Di\ProviderInterface;
 final readonly class AuraSqlQueryUpdateProvider implements ProviderInterface
 {
     /** @param string $db The database type */
-    public function __construct(#[AuraSqlQueryConfig]
-    private string $db)
-    {
+    public function __construct(
+        #[AuraSqlQueryConfig]
+        private string $db
+    ) {
     }
 
     /**

--- a/src/AuraSqlReplicationModule.php
+++ b/src/AuraSqlReplicationModule.php
@@ -28,14 +28,20 @@ final class AuraSqlReplicationModule extends AbstractModule
     #[Override]
     protected function configure(): void
     {
-        $this->bind(ConnectionLocatorInterface::class)
-            ->annotatedWith($this->qualifer)
-            ->toInstance($this->connectionLocator);
+        $locatorBinding = $this->bind(ConnectionLocatorInterface::class);
+        if ($this->qualifer !== '') {
+            $locatorBinding = $locatorBinding->annotatedWith($this->qualifer);
+        }
+
+        $locatorBinding->toInstance($this->connectionLocator);
 
         // ReadOnlyConnection when GET, otherwise WriteConnection
-        $this->bind(ExtendedPdoInterface::class)
-            ->annotatedWith($this->qualifer)
-            ->toProvider(AuraSqlReplicationDbProvider::class, $this->qualifer)
+        $pdoBinding = $this->bind(ExtendedPdoInterface::class);
+        if ($this->qualifer !== '') {
+            $pdoBinding = $pdoBinding->annotatedWith($this->qualifer);
+        }
+
+        $pdoBinding->toProvider(AuraSqlReplicationDbProvider::class, $this->qualifer)
             ->in(Scope::SINGLETON);
 
         // @ReadOnlyConnection @WriteConnection

--- a/src/AuraSqlReplicationModule.php
+++ b/src/AuraSqlReplicationModule.php
@@ -28,20 +28,16 @@ final class AuraSqlReplicationModule extends AbstractModule
     #[Override]
     protected function configure(): void
     {
-        $locatorBinding = $this->bind(ConnectionLocatorInterface::class);
-        if ($this->qualifer !== '') {
-            $locatorBinding = $locatorBinding->annotatedWith($this->qualifer);
-        }
-
-        $locatorBinding->toInstance($this->connectionLocator);
+        $this->bind(ConnectionLocatorInterface::class)
+            /** @phpstan-ignore argument.type */
+            ->annotatedWith($this->qualifer)
+            ->toInstance($this->connectionLocator);
 
         // ReadOnlyConnection when GET, otherwise WriteConnection
-        $pdoBinding = $this->bind(ExtendedPdoInterface::class);
-        if ($this->qualifer !== '') {
-            $pdoBinding = $pdoBinding->annotatedWith($this->qualifer);
-        }
-
-        $pdoBinding->toProvider(AuraSqlReplicationDbProvider::class, $this->qualifer)
+        $this->bind(ExtendedPdoInterface::class)
+            /** @phpstan-ignore argument.type */
+            ->annotatedWith($this->qualifer)
+            ->toProvider(AuraSqlReplicationDbProvider::class, $this->qualifer)
             ->in(Scope::SINGLETON);
 
         // @ReadOnlyConnection @WriteConnection

--- a/src/AuraSqlReplicationModule.php
+++ b/src/AuraSqlReplicationModule.php
@@ -28,6 +28,29 @@ final class AuraSqlReplicationModule extends AbstractModule
     #[Override]
     protected function configure(): void
     {
+        if ($this->qualifer === '') {
+            $this->configureWithoutQualifier();
+        } else {
+            $this->configureWithQualifier();
+        }
+
+        // @ReadOnlyConnection @WriteConnection
+        $this->installReadWriteConnection();
+    }
+
+    private function configureWithoutQualifier(): void
+    {
+        $this->bind(ConnectionLocatorInterface::class)
+            ->toInstance($this->connectionLocator);
+
+        // ReadOnlyConnection when GET, otherwise WriteConnection
+        $this->bind(ExtendedPdoInterface::class)
+            ->toProvider(AuraSqlReplicationDbProvider::class, '')
+            ->in(Scope::SINGLETON);
+    }
+
+    private function configureWithQualifier(): void
+    {
         $this->bind(ConnectionLocatorInterface::class)
             /** @phpstan-ignore argument.type */
             ->annotatedWith($this->qualifer)
@@ -39,9 +62,6 @@ final class AuraSqlReplicationModule extends AbstractModule
             ->annotatedWith($this->qualifer)
             ->toProvider(AuraSqlReplicationDbProvider::class, $this->qualifer)
             ->in(Scope::SINGLETON);
-
-        // @ReadOnlyConnection @WriteConnection
-        $this->installReadWriteConnection();
     }
 
     protected function installReadWriteConnection(): void

--- a/src/NamedPdoEnvModule.php
+++ b/src/NamedPdoEnvModule.php
@@ -55,22 +55,17 @@ final class NamedPdoEnvModule extends AbstractModule
             $this->options,
             $this->queries,
         );
-        $connectionBinding = $this->bind(EnvConnection::class);
-        if ($this->qualifer !== '') {
-            $connectionBinding = $connectionBinding->annotatedWith($this->qualifer);
-        }
-
-        $connectionBinding->toInstance($connection);
-
-        $pdoBinding = $this->bind(ExtendedPdoInterface::class);
-        if ($this->qualifer !== '') {
-            $pdoBinding = $pdoBinding->annotatedWith($this->qualifer);
-        }
-
-        $pdoBinding->toProvider(
-            NamedExtendedPdoProvider::class,
-            $this->qualifer,
-        );
+        $this->bind(EnvConnection::class)
+            /** @phpstan-ignore argument.type */
+            ->annotatedWith($this->qualifer)
+            ->toInstance($connection);
+        $this->bind(ExtendedPdoInterface::class)
+            /** @phpstan-ignore argument.type */
+            ->annotatedWith($this->qualifer)
+            ->toProvider(
+                NamedExtendedPdoProvider::class,
+                $this->qualifer,
+            );
     }
 
     private function configureMasterSlaveDsn(): void

--- a/src/NamedPdoEnvModule.php
+++ b/src/NamedPdoEnvModule.php
@@ -55,8 +55,19 @@ final class NamedPdoEnvModule extends AbstractModule
             $this->options,
             $this->queries,
         );
-        $this->bind(EnvConnection::class)->annotatedWith($this->qualifer)->toInstance($connection);
-        $this->bind(ExtendedPdoInterface::class)->annotatedWith($this->qualifer)->toProvider(
+        $connectionBinding = $this->bind(EnvConnection::class);
+        if ($this->qualifer !== '') {
+            $connectionBinding = $connectionBinding->annotatedWith($this->qualifer);
+        }
+
+        $connectionBinding->toInstance($connection);
+
+        $pdoBinding = $this->bind(ExtendedPdoInterface::class);
+        if ($this->qualifer !== '') {
+            $pdoBinding = $pdoBinding->annotatedWith($this->qualifer);
+        }
+
+        $pdoBinding->toProvider(
             NamedExtendedPdoProvider::class,
             $this->qualifer,
         );

--- a/src/NamedPdoEnvModule.php
+++ b/src/NamedPdoEnvModule.php
@@ -47,6 +47,32 @@ final class NamedPdoEnvModule extends AbstractModule
 
     private function configureSingleDsn(): void
     {
+        if ($this->qualifer === '') {
+            $this->configureSingleDsnWithoutQualifier();
+        } else {
+            $this->configureSingleDsnWithQualifier();
+        }
+    }
+
+    private function configureSingleDsnWithoutQualifier(): void
+    {
+        $connection = new EnvConnection(
+            $this->dsn,
+            null,
+            $this->username,
+            $this->password,
+            $this->options,
+            $this->queries,
+        );
+        $this->bind(EnvConnection::class)->toInstance($connection);
+        $this->bind(ExtendedPdoInterface::class)->toProvider(
+            NamedExtendedPdoProvider::class,
+            '',
+        );
+    }
+
+    private function configureSingleDsnWithQualifier(): void
+    {
         $connection = new EnvConnection(
             $this->dsn,
             null,

--- a/src/NamedPdoModule.php
+++ b/src/NamedPdoModule.php
@@ -7,6 +7,7 @@ namespace Ray\AuraSqlModule;
 use Aura\Sql\ConnectionLocator;
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
+use InvalidArgumentException;
 use Override;
 use Ray\Di\AbstractModule;
 use SensitiveParameter;
@@ -36,6 +37,13 @@ final class NamedPdoModule extends AbstractModule
         /** @var array<string> */
         private readonly array $queries = []
     ) {
+        if ($this->qualifer === '') {
+            throw new InvalidArgumentException(
+                'NamedPdoModule requires a non-empty qualifier. ' .
+                'Use AuraSqlModule instead for unqualified bindings.',
+            );
+        }
+
         parent::__construct();
     }
 
@@ -51,33 +59,7 @@ final class NamedPdoModule extends AbstractModule
 
     private function configureSingleDsn(): void
     {
-        if ($this->qualifer === '') {
-            $this->configureSingleDsnWithoutQualifier();
-        } else {
-            $this->configureSingleDsnWithQualifier();
-        }
-    }
-
-    private function configureSingleDsnWithoutQualifier(): void
-    {
         $this->bind(ExtendedPdoInterface::class)
-            ->toConstructor(
-                ExtendedPdo::class,
-                [
-                    'dsn' => '_dsn',
-                    'username' => '_username',
-                    'password' => '_password',
-                ],
-            );
-        $this->bind()->annotatedWith('_dsn')->toInstance($this->dsn);
-        $this->bind()->annotatedWith('_username')->toInstance($this->username);
-        $this->bind()->annotatedWith('_password')->toInstance($this->password);
-    }
-
-    private function configureSingleDsnWithQualifier(): void
-    {
-        $this->bind(ExtendedPdoInterface::class)
-            /** @phpstan-ignore argument.type */
             ->annotatedWith($this->qualifer)
             ->toConstructor(
                 ExtendedPdo::class,

--- a/src/NamedPdoModule.php
+++ b/src/NamedPdoModule.php
@@ -67,11 +67,15 @@ final class NamedPdoModule extends AbstractModule
                     'dsn' => "{$this->qualifer}_dsn",
                     'username' => "{$this->qualifer}_username",
                     'password' => "{$this->qualifer}_password",
+                    'driver_options' => "{$this->qualifer}_options",
+                    'after_connect' => "{$this->qualifer}_queries",
                 ],
             );
         $this->bind()->annotatedWith("{$this->qualifer}_dsn")->toInstance($this->dsn);
         $this->bind()->annotatedWith("{$this->qualifer}_username")->toInstance($this->username);
         $this->bind()->annotatedWith("{$this->qualifer}_password")->toInstance($this->password);
+        $this->bind()->annotatedWith("{$this->qualifer}_options")->toInstance($this->options);
+        $this->bind()->annotatedWith("{$this->qualifer}_queries")->toInstance($this->queries);
     }
 
     private function configureMasterSlaveDsn(): void

--- a/src/NamedPdoModule.php
+++ b/src/NamedPdoModule.php
@@ -51,19 +51,17 @@ final class NamedPdoModule extends AbstractModule
 
     private function configureSingleDsn(): void
     {
-        $pdoBinding = $this->bind(ExtendedPdoInterface::class);
-        if ($this->qualifer !== '') {
-            $pdoBinding = $pdoBinding->annotatedWith($this->qualifer);
-        }
-
-        $pdoBinding->toConstructor(
-            ExtendedPdo::class,
-            [
-                'dsn' => "{$this->qualifer}_dsn",
-                'username' => "{$this->qualifer}_username",
-                'password' => "{$this->qualifer}_password",
-            ],
-        );
+        $this->bind(ExtendedPdoInterface::class)
+            /** @phpstan-ignore argument.type */
+            ->annotatedWith($this->qualifer)
+            ->toConstructor(
+                ExtendedPdo::class,
+                [
+                    'dsn' => "{$this->qualifer}_dsn",
+                    'username' => "{$this->qualifer}_username",
+                    'password' => "{$this->qualifer}_password",
+                ],
+            );
         $this->bind()->annotatedWith("{$this->qualifer}_dsn")->toInstance($this->dsn);
         $this->bind()->annotatedWith("{$this->qualifer}_username")->toInstance($this->username);
         $this->bind()->annotatedWith("{$this->qualifer}_password")->toInstance($this->password);

--- a/src/NamedPdoModule.php
+++ b/src/NamedPdoModule.php
@@ -51,16 +51,19 @@ final class NamedPdoModule extends AbstractModule
 
     private function configureSingleDsn(): void
     {
-        $this->bind(ExtendedPdoInterface::class)
-            ->annotatedWith($this->qualifer)
-            ->toConstructor(
-                ExtendedPdo::class,
-                [
-                    'dsn' => "{$this->qualifer}_dsn",
-                    'username' => "{$this->qualifer}_username",
-                    'password' => "{$this->qualifer}_password",
-                ],
-            );
+        $pdoBinding = $this->bind(ExtendedPdoInterface::class);
+        if ($this->qualifer !== '') {
+            $pdoBinding = $pdoBinding->annotatedWith($this->qualifer);
+        }
+
+        $pdoBinding->toConstructor(
+            ExtendedPdo::class,
+            [
+                'dsn' => "{$this->qualifer}_dsn",
+                'username' => "{$this->qualifer}_username",
+                'password' => "{$this->qualifer}_password",
+            ],
+        );
         $this->bind()->annotatedWith("{$this->qualifer}_dsn")->toInstance($this->dsn);
         $this->bind()->annotatedWith("{$this->qualifer}_username")->toInstance($this->username);
         $this->bind()->annotatedWith("{$this->qualifer}_password")->toInstance($this->password);

--- a/src/NamedPdoModule.php
+++ b/src/NamedPdoModule.php
@@ -55,7 +55,11 @@ final class NamedPdoModule extends AbstractModule
             ->annotatedWith($this->qualifer)
             ->toConstructor(
                 ExtendedPdo::class,
-                "dsn={$this->qualifer}_dsn,username={$this->qualifer}_username,password={$this->qualifer}_password",
+                [
+                    'dsn' => "{$this->qualifer}_dsn",
+                    'username' => "{$this->qualifer}_username",
+                    'password' => "{$this->qualifer}_password",
+                ],
             );
         $this->bind()->annotatedWith("{$this->qualifer}_dsn")->toInstance($this->dsn);
         $this->bind()->annotatedWith("{$this->qualifer}_username")->toInstance($this->username);

--- a/src/NamedPdoModule.php
+++ b/src/NamedPdoModule.php
@@ -51,6 +51,31 @@ final class NamedPdoModule extends AbstractModule
 
     private function configureSingleDsn(): void
     {
+        if ($this->qualifer === '') {
+            $this->configureSingleDsnWithoutQualifier();
+        } else {
+            $this->configureSingleDsnWithQualifier();
+        }
+    }
+
+    private function configureSingleDsnWithoutQualifier(): void
+    {
+        $this->bind(ExtendedPdoInterface::class)
+            ->toConstructor(
+                ExtendedPdo::class,
+                [
+                    'dsn' => '_dsn',
+                    'username' => '_username',
+                    'password' => '_password',
+                ],
+            );
+        $this->bind()->annotatedWith('_dsn')->toInstance($this->dsn);
+        $this->bind()->annotatedWith('_username')->toInstance($this->username);
+        $this->bind()->annotatedWith('_password')->toInstance($this->password);
+    }
+
+    private function configureSingleDsnWithQualifier(): void
+    {
         $this->bind(ExtendedPdoInterface::class)
             /** @phpstan-ignore argument.type */
             ->annotatedWith($this->qualifer)

--- a/src/Pagerfanta/AuraSqlPager.php
+++ b/src/Pagerfanta/AuraSqlPager.php
@@ -32,9 +32,11 @@ final class AuraSqlPager implements AuraSqlPagerInterface
     private int $paging;
 
     /** @param array<string, mixed> $viewOptions */
-    public function __construct(private readonly ViewInterface $view, #[PagerViewOption]
-    private readonly array $viewOptions)
-    {
+    public function __construct(
+        private readonly ViewInterface $view,
+        #[PagerViewOption]
+        private readonly array $viewOptions
+    ) {
     }
 
     /**

--- a/src/Pagerfanta/AuraSqlPager.php
+++ b/src/Pagerfanta/AuraSqlPager.php
@@ -32,8 +32,8 @@ final class AuraSqlPager implements AuraSqlPagerInterface
     private int $paging;
 
     /** @param array<string, mixed> $viewOptions */
-    #[PagerViewOption('viewOptions')]
-    public function __construct(private readonly ViewInterface $view, private readonly array $viewOptions)
+    public function __construct(private readonly ViewInterface $view, #[PagerViewOption]
+    private readonly array $viewOptions)
     {
     }
 

--- a/src/Pagerfanta/AuraSqlQueryPager.php
+++ b/src/Pagerfanta/AuraSqlQueryPager.php
@@ -29,8 +29,8 @@ final class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, ArrayAccess
     private int $paging;
 
     /** @param array<string, mixed> $viewOptions */
-    #[PagerViewOption('viewOptions')]
-    public function __construct(private readonly ViewInterface $view, private readonly array $viewOptions)
+    public function __construct(private readonly ViewInterface $view, #[PagerViewOption]
+    private readonly array $viewOptions)
     {
     }
 

--- a/src/Pagerfanta/AuraSqlQueryPager.php
+++ b/src/Pagerfanta/AuraSqlQueryPager.php
@@ -29,9 +29,11 @@ final class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, ArrayAccess
     private int $paging;
 
     /** @param array<string, mixed> $viewOptions */
-    public function __construct(private readonly ViewInterface $view, #[PagerViewOption]
-    private readonly array $viewOptions)
-    {
+    public function __construct(
+        private readonly ViewInterface $view,
+        #[PagerViewOption]
+        private readonly array $viewOptions
+    ) {
     }
 
     /**

--- a/tests/AuraSqlModuleTest.php
+++ b/tests/AuraSqlModuleTest.php
@@ -10,8 +10,6 @@ use Aura\Sql\ExtendedPdoInterface;
 use PHPUnit\Framework\TestCase;
 use Ray\Compiler\CompiledInjector;
 use Ray\Compiler\Compiler;
-use Ray\Compiler\DiCompiler;
-use Ray\Compiler\ScriptInjector;
 use Ray\Di\Injector;
 use Ray\Di\Instance;
 use ReflectionProperty;

--- a/tests/AuraSqlModuleTest.php
+++ b/tests/AuraSqlModuleTest.php
@@ -8,6 +8,8 @@ use Aura\Sql\ConnectionLocatorInterface;
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
 use PHPUnit\Framework\TestCase;
+use Ray\Compiler\CompiledInjector;
+use Ray\Compiler\Compiler;
 use Ray\Compiler\DiCompiler;
 use Ray\Compiler\ScriptInjector;
 use Ray\Di\Injector;
@@ -26,8 +28,11 @@ class AuraSqlModuleTest extends TestCase
 
     public function testCompile()
     {
-        new DiCompiler(new AuraSqlModule('sqlite::memory:'), __DIR__ . '/tmp')->compile();
-        $pdo = new ScriptInjector(__DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class);
+        $compiler = new Compiler();
+        $scriptDir = __DIR__ . '/tmp';
+        $compiler->compile(new AuraSqlModule('sqlite::memory:'), $scriptDir);
+        $injector = new CompiledInjector($scriptDir);
+        $pdo = $injector->getInstance(ExtendedPdoInterface::class);
         $this->assertInstanceOf(ExtendedPdoInterface::class, $pdo);
     }
 

--- a/tests/Fake/FakeLogDb.php
+++ b/tests/Fake/FakeLogDb.php
@@ -7,7 +7,7 @@ use Aura\Sql\ExtendedPdoInterface;
 use Ray\Di\Di\Named;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+#[Attribute(Attribute::TARGET_PARAMETER), Qualifier]
 final class FakeLogDb
 {
 }

--- a/tests/Fake/FakeLogDbInject.php
+++ b/tests/Fake/FakeLogDbInject.php
@@ -9,7 +9,7 @@ use Ray\Di\Di\Named;
 use Ray\Di\Di\Qualifier;
 use Ray\Di\InjectorInterface;
 
-#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER), Qualifier]
 final class FakeLogDbInject implements InjectInterface
 {
     public $optional = true;

--- a/tests/Fake/FakeMultiDb.php
+++ b/tests/Fake/FakeMultiDb.php
@@ -16,9 +16,11 @@ class FakeMultiDb
     protected $pdo2;
     protected $pdo3;
 
-    #[Named('pdo1=pdo1,pdo2=pdo2,pdo3=pdo3')]
-    public function __construct(ExtendedPdoInterface $pdo1, ExtendedPdoInterface $pdo2, ExtendedPdoInterface $pdo3)
-    {
+    public function __construct(
+        #[Named('pdo1')] ExtendedPdoInterface $pdo1,
+        #[Named('pdo2')] ExtendedPdoInterface $pdo2,
+        #[Named('pdo3')] ExtendedPdoInterface $pdo3
+    ) {
         $this->pdo1 = $pdo1;
         $this->pdo2 = $pdo2;
         $this->pdo3 = $pdo3;

--- a/tests/Fake/FakeMultiDb.php
+++ b/tests/Fake/FakeMultiDb.php
@@ -17,9 +17,12 @@ class FakeMultiDb
     protected $pdo3;
 
     public function __construct(
-        #[Named('pdo1')] ExtendedPdoInterface $pdo1,
-        #[Named('pdo2')] ExtendedPdoInterface $pdo2,
-        #[Named('pdo3')] ExtendedPdoInterface $pdo3
+        #[Named('pdo1')]
+        ExtendedPdoInterface $pdo1,
+        #[Named('pdo2')]
+        ExtendedPdoInterface $pdo2,
+        #[Named('pdo3')]
+        ExtendedPdoInterface $pdo3
     ) {
         $this->pdo1 = $pdo1;
         $this->pdo2 = $pdo2;

--- a/tests/Fake/FakeName.php
+++ b/tests/Fake/FakeName.php
@@ -12,29 +12,19 @@ class FakeName
     public $pdoAnno;
     public $pdoSetterInject;
 
-    /**
-     * @Named("log_db")
-     */
     public function __construct(#[Named('log_db')] ExtendedPdoInterface $pdo)
     {
         $this->pdo = $pdo;
     }
 
-    /**
-     * @Inject
-     * @FakeLogDb
-     */
     #[Inject]
     public function setFakeDb(#[FakeLogDb] ExtendedPdoInterface $pdo)
     {
         $this->pdoAnno = $pdo;
     }
 
-    /**
-     * @FakeLogDbInject
-     */
     #[FakeLogDbInject]
-    public function setFakeDbWithInjectAnnotation(ExtendedPdoInterface $pdo)
+    public function setFakeDbWithInjectAnnotation(#[FakeLogDbInject] ExtendedPdoInterface $pdo)
     {
         $this->pdoSetterInject = $pdo;
     }

--- a/tests/Fake/FakeName.php
+++ b/tests/Fake/FakeName.php
@@ -12,20 +12,26 @@ class FakeName
     public $pdoAnno;
     public $pdoSetterInject;
 
-    public function __construct(#[Named('log_db')] ExtendedPdoInterface $pdo)
-    {
+    public function __construct(
+        #[Named('log_db')]
+        ExtendedPdoInterface $pdo
+    ) {
         $this->pdo = $pdo;
     }
 
     #[Inject]
-    public function setFakeDb(#[FakeLogDb] ExtendedPdoInterface $pdo)
-    {
+    public function setFakeDb(
+        #[FakeLogDb]
+        ExtendedPdoInterface $pdo
+    ) {
         $this->pdoAnno = $pdo;
     }
 
     #[FakeLogDbInject]
-    public function setFakeDbWithInjectAnnotation(#[FakeLogDbInject] ExtendedPdoInterface $pdo)
-    {
+    public function setFakeDbWithInjectAnnotation(
+        #[FakeLogDbInject]
+        ExtendedPdoInterface $pdo
+    ) {
         $this->pdoSetterInject = $pdo;
     }
 }

--- a/tests/Fake/FakeName.php
+++ b/tests/Fake/FakeName.php
@@ -15,8 +15,7 @@ class FakeName
     /**
      * @Named("log_db")
      */
-    #[Named('log_db')]
-    public function __construct(ExtendedPdoInterface $pdo)
+    public function __construct(#[Named('log_db')] ExtendedPdoInterface $pdo)
     {
         $this->pdo = $pdo;
     }
@@ -25,8 +24,8 @@ class FakeName
      * @Inject
      * @FakeLogDb
      */
-    #[Inject, FakeLogDb]
-    public function setFakeDb(ExtendedPdoInterface $pdo)
+    #[Inject]
+    public function setFakeDb(#[FakeLogDb] ExtendedPdoInterface $pdo)
     {
         $this->pdoAnno = $pdo;
     }

--- a/tests/Fake/FakeQueryInject.php
+++ b/tests/Fake/FakeQueryInject.php
@@ -12,8 +12,7 @@ class FakeQueryInject
     use AuraSqlDeleteInject;
 
     /** @param string $db */
-    #[AuraSqlQueryConfig]
-    public function __construct(private string $db)
+    public function __construct(#[AuraSqlQueryConfig] private string $db)
     {
     }
 

--- a/tests/Fake/FakeQueryInject.php
+++ b/tests/Fake/FakeQueryInject.php
@@ -12,8 +12,10 @@ class FakeQueryInject
     use AuraSqlDeleteInject;
 
     /** @param string $db */
-    public function __construct(#[AuraSqlQueryConfig] private string $db)
-    {
+    public function __construct(
+        #[AuraSqlQueryConfig]
+        private string $db
+    ) {
     }
 
     public function get()

--- a/tests/NamedPdoModuleTest.php
+++ b/tests/NamedPdoModuleTest.php
@@ -6,6 +6,7 @@ namespace Ray\AuraSqlModule;
 
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 use ReflectionProperty;
@@ -19,6 +20,14 @@ class NamedPdoModuleTest extends TestCase
         $qualifer = 'log_db';
         $instance = new Injector(new NamedPdoModule($qualifer, 'sqlite::memory:'), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class, $qualifer);
         $this->assertInstanceOf(ExtendedPdo::class, $instance);
+    }
+
+    public function testEmptyQualifierThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('NamedPdoModule requires a non-empty qualifier');
+
+        new NamedPdoModule('', 'sqlite::memory:');
     }
 
     public function testFakeName()

--- a/tests/NamedPdoModuleTest.php
+++ b/tests/NamedPdoModuleTest.php
@@ -25,7 +25,7 @@ class NamedPdoModuleTest extends TestCase
     public function testEmptyQualifierThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('NamedPdoModule requires a non-empty qualifier');
+        $this->expectExceptionMessage('NamedPdoModule requires a non-empty qualifier. Use AuraSqlModule instead for unqualified bindings.');
 
         new NamedPdoModule('', 'sqlite::memory:');
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,14 +2,6 @@
 
 declare(strict_types=1);
 
-use Koriym\Attributes\AttributeReader;
-use Ray\ServiceLocator\ServiceLocator;
-
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 array_map(unlink(...), (array) glob(__DIR__ . '/tmp/*.{php,txt}', GLOB_BRACE));
-
-// no annotation in PHP 8
-if (PHP_MAJOR_VERSION >= 8) {
-    ServiceLocator::setReader(new AttributeReader());
-}

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -1134,29 +1134,29 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.1.2",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
                 "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
@@ -1226,7 +1226,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-07-17T20:45:56+00:00"
+            "time": "2025-11-11T04:32:07+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1546,33 +1546,38 @@
         },
         {
             "name": "league/uri",
-            "version": "7.5.1",
+            "version": "7.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430"
+                "reference": "f625804987a0a9112d954f9209d91fec52182344"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/81fb5145d2644324614cc532b28efd0215bda430",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/f625804987a0a9112d954f9209d91fec52182344",
+                "reference": "f625804987a0a9112d954f9209d91fec52182344",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.5",
-                "php": "^8.1"
+                "league/uri-interfaces": "^7.6",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
             },
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
             "suggest": {
                 "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
                 "ext-fileinfo": "to create Data URI from file contennts",
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
                 "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
                 "league/uri-components": "Needed to easily manipulate URI objects components",
+                "league/uri-polyfill": "Needed to backport the PHP URI extension for older versions of PHP",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle WHATWG URL",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -1600,6 +1605,7 @@
             "description": "URI manipulation library",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
+                "URN",
                 "data-uri",
                 "file-uri",
                 "ftp",
@@ -1612,9 +1618,11 @@
                 "psr-7",
                 "query-string",
                 "querystring",
+                "rfc2141",
                 "rfc3986",
                 "rfc3987",
                 "rfc6570",
+                "rfc8141",
                 "uri",
                 "uri-template",
                 "url",
@@ -1624,7 +1632,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.5.1"
+                "source": "https://github.com/thephpleague/uri/tree/7.6.0"
             },
             "funding": [
                 {
@@ -1632,26 +1640,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:40:02+00:00"
+            "time": "2025-11-18T12:17:23+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.5.0",
+            "version": "7.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742"
+                "reference": "ccbfb51c0445298e7e0b7f4481b942f589665368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/ccbfb51c0445298e7e0b7f4481b942f589665368",
+                "reference": "ccbfb51c0445298e7e0b7f4481b942f589665368",
                 "shasum": ""
             },
             "require": {
                 "ext-filter": "*",
                 "php": "^8.1",
-                "psr/http-factory": "^1",
                 "psr/http-message": "^1.1 || ^2.0"
             },
             "suggest": {
@@ -1659,6 +1666,7 @@
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle WHATWG URL",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -1683,7 +1691,7 @@
                     "homepage": "https://nyamsprod.com"
                 }
             ],
-            "description": "Common interfaces and classes for URI representation and interaction",
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
                 "data-uri",
@@ -1708,7 +1716,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.5.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.6.0"
             },
             "funding": [
                 {
@@ -1716,7 +1724,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:18:47+00:00"
+            "time": "2025-11-18T12:17:23+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -1946,16 +1954,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.10.0",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a"
+                "reference": "431c02da15e566adb0ad9c5030fa6f6204d9de9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/679e3ce485b99e84c775d28e2e96fade9a7fb50a",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/431c02da15e566adb0ad9c5030fa6f6204d9de9e",
+                "reference": "431c02da15e566adb0ad9c5030fa6f6204d9de9e",
                 "shasum": ""
             },
             "require": {
@@ -1998,9 +2006,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.1"
             },
-            "time": "2024-11-09T15:12:26+00:00"
+            "time": "2025-11-18T07:51:16+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -2051,11 +2059,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.31",
+            "version": "2.1.32",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ead89849d879fe203ce9292c6ef5e7e76f867b96",
-                "reference": "ead89849d879fe203ce9292c6ef5e7e76f867b96",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e126cad1e30a99b137b8ed75a85a676450ebb227",
+                "reference": "e126cad1e30a99b137b8ed75a85a676450ebb227",
                 "shasum": ""
             },
             "require": {
@@ -2100,7 +2108,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-10T14:14:11+00:00"
+            "time": "2025-11-11T15:18:17+00:00"
         },
         {
             "name": "psr/container",
@@ -2315,21 +2323,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.2.7",
+            "version": "2.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "022038537838bc8a4e526af86c2d6e38eaeff7ef"
+                "reference": "303aa811649ccd1d32e51e62d5c85949d01b5f1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/022038537838bc8a4e526af86c2d6e38eaeff7ef",
-                "reference": "022038537838bc8a4e526af86c2d6e38eaeff7ef",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/303aa811649ccd1d32e51e62d5c85949d01b5f1b",
+                "reference": "303aa811649ccd1d32e51e62d5c85949d01b5f1b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.26"
+                "phpstan/phpstan": "^2.1.32"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -2363,7 +2371,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.2.7"
+                "source": "https://github.com/rectorphp/rector/tree/2.2.8"
             },
             "funding": [
                 {
@@ -2371,7 +2379,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-29T15:46:12+00:00"
+            "time": "2025-11-12T18:38:00+00:00"
         },
         {
             "name": "revolt/event-loop",
@@ -2579,16 +2587,16 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67"
+                "reference": "6a740f39415aee8886aea10333403adc77d50791"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67",
-                "reference": "7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/6a740f39415aee8886aea10333403adc77d50791",
+                "reference": "6a740f39415aee8886aea10333403adc77d50791",
                 "shasum": ""
             },
             "require": {
@@ -2631,7 +2639,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/3.4.0"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.4.1"
             },
             "funding": [
                 {
@@ -2643,20 +2651,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-16T12:45:15+00:00"
+            "time": "2025-11-12T10:32:50+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "06113cfdaf117fc2165f9cd040bd0f17fcd5242d"
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/06113cfdaf117fc2165f9cd040bd0f17fcd5242d",
-                "reference": "06113cfdaf117fc2165f9cd040bd0f17fcd5242d",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
                 "shasum": ""
             },
             "require": {
@@ -2722,7 +2730,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-09-15T11:28:58+00:00"
+            "time": "2025-11-10T16:43:36+00:00"
         },
         {
             "name": "symfony/console",


### PR DESCRIPTION
## Summary

This PR migrates Ray.AuraSqlModule to use parameter-level attributes for dependency injection, ensuring compatibility with Ray.Di 2.19.1.

## Changes

### Attribute Definitions
Updated qualifier attributes to target parameters instead of methods:
- `AuraSqlQueryConfig`: `TARGET_METHOD` → `TARGET_PARAMETER`
- `EnvAuth`: `TARGET_METHOD` → `TARGET_PARAMETER`
- `PagerViewOption`: `TARGET_METHOD` → `TARGET_PARAMETER`, made `$value` optional
- `FakeLogDb`: `TARGET_METHOD` → `TARGET_PARAMETER` (test fixture)

### Implementation Updates
Moved attributes from method-level to parameter-level in:
- Provider classes: `AuraSqlQuerySelectProvider`, `AuraSqlQueryInsertProvider`, `AuraSqlQueryUpdateProvider`, `AuraSqlQueryDeleteProvider`
- Pager: `AuraSqlPager`
- Test fixtures: `FakeName`, `FakeQueryInject`, `FakeMultiDb`

### Module Configuration
Migrated `toConstructor()` calls from legacy string format to array format:
- `AuraSqlModule`: `'dsn=pdo_dsn,username=pdo_user'` → `['dsn' => 'pdo_dsn', 'username' => 'pdo_user']`
- `AuraSqlMasterModule` and `NamedPdoModule`: Similar conversions

#### Qualifier Validation and PHPStan Compatibility
- **NamedPdoModule**: Added constructor validation to reject empty qualifiers with `InvalidArgumentException`
  - Clear error message directs users to `AuraSqlModule` for unqualified bindings
  - Simplified configure() logic - no conditional bindings needed
- **NamedPdoEnvModule**: Retains support for both empty and non-empty qualifiers via method splitting
  - Required for backward compatibility (used internally by `AuraSqlEnvModule`)
- **AuraSqlReplicationModule**: Refactored to use method splitting pattern
  - Eliminated conditional bindings anti-pattern in configure()
  - Separate methods for qualified/unqualified paths improve maintainability

### Cleanup
- Removed deprecated `ServiceLocator` setup from `tests/bootstrap.php`
- Removed coverage configuration from `phpunit.xml.dist` (coverage generated only when explicitly requested)

## Rationale

Ray.Di 2.19.0 removed method-level attribute support for qualified parameters, requiring parameter-level attributes as the recommended best practice. This aligns with PHP 8's native attribute targeting and improves code clarity by placing attributes directly on the parameters they qualify.

The module refactoring addresses PHPStan type inference issues (`annotatedWith()` expects `non-empty-string`) while avoiding anti-patterns:
- Empty qualifier validation in `NamedPdoModule` enforces proper API usage
- Method splitting eliminates conditional bindings in `configure()` methods
- Maintains backward compatibility where needed

## Testing

- All tests pass: 76 tests, 145 assertions
- Added test for `NamedPdoModule` empty qualifier validation
- PHPStan: No errors
- PHPCS: No violations
- Psalm: No errors

## Related

- Depends on ray-di/Ray.Di#306 (Ray.Di 2.19.1)
- Part of Ray.MediaQuery 1.0 release preparation