### PR TITLE
Migrate to parameter-level attributes for Ray.Di 2.19.1 (1.13.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     "require": {
         "php": "^8.0",
         "ext-pdo": "*",
-        "ray/di": "^2.13.1",
-        "ray/aop": "^2.10.4",
+        "ray/di": "^2.19.1",
+        "ray/aop": "^2.19",
         "aura/sql": "^4.0 || ^5.0",
         "aura/sqlquery": "^2.7.1 || ^3.0",
         "pagerfanta/pagerfanta": "^3.5",
@@ -22,8 +22,8 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "bamarni/composer-bin-plugin": "^1.4",
-        "maglnet/composer-require-checker": "^3.0"
-
+        "maglnet/composer-require-checker": "^3.0",
+        "ray/compiler": "^1.13"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php">
-  <coverage processUncoveredFiles="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         requireCoverageMetadata="false">
+  <source>
     <include>
       <directory suffix=".php">src</directory>
     </include>
-  </coverage>
+  </source>
+
   <testsuites>
     <testsuite name="all">
       <directory>tests</directory>

--- a/src/Annotation/AuraSqlQueryConfig.php
+++ b/src/Annotation/AuraSqlQueryConfig.php
@@ -7,17 +7,13 @@ namespace Ray\AuraSqlModule\Annotation;
 use Attribute;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+#[Attribute(Attribute::TARGET_PARAMETER), Qualifier]
 final class AuraSqlQueryConfig
 {
-    /** @var ?array<string, string> */
-    public $value;
-
     /**
-     * @param array<string, string> $value
+     * @param array<string, string>|null $value
      */
-    public function __construct(?array $value = null)
+    public function __construct(public ?array $value = null)
     {
-        $this->value = $value;
     }
 }

--- a/src/Annotation/EnvAuth.php
+++ b/src/Annotation/EnvAuth.php
@@ -7,7 +7,7 @@ namespace Ray\AuraSqlModule\Annotation;
 use Attribute;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+#[Attribute(Attribute::TARGET_PARAMETER), Qualifier]
 final class EnvAuth
 {
 }

--- a/src/Annotation/PagerViewOption.php
+++ b/src/Annotation/PagerViewOption.php
@@ -7,10 +7,10 @@ namespace Ray\AuraSqlModule\Annotation;
 use Attribute;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+#[Attribute(Attribute::TARGET_PARAMETER), Qualifier]
 final class PagerViewOption
 {
-    public function __construct(public string $value)
+    public function __construct(public string $value = '')
     {
     }
 }

--- a/src/AuraSqlMasterModule.php
+++ b/src/AuraSqlMasterModule.php
@@ -6,50 +6,46 @@ namespace Ray\AuraSqlModule;
 
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
+use Override;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
+use SensitiveParameter;
 
-class AuraSqlMasterModule extends AbstractModule
+final class AuraSqlMasterModule extends AbstractModule
 {
-    private string $dsn;
-    private string $user;
-    private string $password;
-
-    /** @var array<string> */
-    private array $options;
-
-    /** @var array<string> */
-    private array $attributes;
-
     /**
-     * @phpstan-param array<string> $options
-     * @phpstan-param array<string> $attributes
+     * @phpstan-param array<string, mixed> $options
+     * @phpstan-param array<string, mixed> $attributes
      */
     public function __construct(
-        string $dsnKey,
-        string $user = '',
-        string $passwordKey = '',
-        array $options = [],
-        array $attributes = [],
+        private readonly string $dsn,
+        private readonly string $user = '',
+        #[SensitiveParameter]
+        private readonly string $password = '',
+        /** @var array<string, mixed> */
+        private readonly array $options = [],
+        /** @var array<string, mixed> */
+        private readonly array $attributes = [],
         ?AbstractModule $module = null
     ) {
-        $this->dsn = $dsnKey;
-        $this->user = $user;
-        $this->password = $passwordKey;
-        $this->options = $options;
-        $this->attributes = $attributes;
-
         parent::__construct($module);
     }
 
     /**
      * {@inheritDoc}
      */
+    #[Override]
     protected function configure(): void
     {
         $this->bind(ExtendedPdoInterface::class)->toConstructor(
             ExtendedPdo::class,
-            'dsn=pdo_dsn,username=pdo_user,password=pdo_pass,options=pdo_option,attributes=pdo_attributes',
+            [
+                'dsn' => 'pdo_dsn',
+                'username' => 'pdo_user',
+                'password' => 'pdo_pass',
+                'options' => 'pdo_option',
+                'attributes' => 'pdo_attributes',
+            ],
         )->in(Scope::SINGLETON);
         $this->bind()->annotatedWith('pdo_dsn')->toInstance($this->dsn);
         $this->bind()->annotatedWith('pdo_user')->toInstance($this->user);

--- a/src/AuraSqlModule.php
+++ b/src/AuraSqlModule.php
@@ -13,7 +13,7 @@ use SensitiveParameter;
 
 final class AuraSqlModule extends AbstractModule
 {
-    public const string PARSE_PDO_DSN_REGEX = '/(.*?):(?:(host|server)=.*?;)?(.*)/i';
+    public const PARSE_PDO_DSN_REGEX = '/(.*?):(?:(host|server)=.*?;)?(.*)/i';
 
     /**
      * @param string              $dsn      Data Source Name (DSN)

--- a/src/AuraSqlModule.php
+++ b/src/AuraSqlModule.php
@@ -6,53 +6,41 @@ namespace Ray\AuraSqlModule;
 
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
+use Override;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
+use SensitiveParameter;
 
-class AuraSqlModule extends AbstractModule
+final class AuraSqlModule extends AbstractModule
 {
-    public const PARSE_PDO_DSN_REGEX = '/(.*?):(?:(host|server)=.*?;)?(.*)/i';
-
-    private string $dsn;
-    private string $user;
-    private string $password;
-    private string $slave;
-
-    /** @var array<string> */
-    private array $options;
-
-    /** @var array<string> */
-    private array $queries;
+    public const string PARSE_PDO_DSN_REGEX = '/(.*?):(?:(host|server)=.*?;)?(.*)/i';
 
     /**
-     * @param string        $dsnKey      Data Source Name (DSN)
-     * @param string        $user        User name for the DSN string
-     * @param string        $passwordKey Password for the DSN string
-     * @param string        $slaveKey    Comma separated slave host list
-     * @param array<string> $options     A key=>value array of driver-specific connection options
-     * @param array<string> $queries
+     * @param string              $dsn      Data Source Name (DSN)
+     * @param string              $user     User name for the DSN string
+     * @param string              $password Password for the DSN string
+     * @param string              $slave    Comma separated slave host list
+     * @param array<string,mixed> $options  A key=>value array of driver-specific connection options
+     * @param array<string>       $queries
      */
     public function __construct(
-        string $dsnKey,
-        string $user = '',
-        string $passwordKey = '',
-        string $slaveKey = '',
-        array $options = [],
-        array $queries = []
+        private readonly string $dsn,
+        private readonly string $user = '',
+        #[SensitiveParameter]
+        private readonly string $password = '',
+        private readonly string $slave = '',
+        /** @var array<string, mixed> */
+        private readonly array $options = [],
+        /** @var array<string> */
+        private readonly array $queries = []
     ) {
-        $this->dsn = $dsnKey;
-        $this->user = $user;
-        $this->password = $passwordKey;
-        $this->slave = $slaveKey;
-        $this->options = $options;
-        $this->queries = $queries;
-
         parent::__construct();
     }
 
     /**
      * {@inheritDoc}
      */
+    #[Override]
     protected function configure(): void
     {
         $this->slave ? $this->configureMasterSlaveDsn() : $this->configureSingleDsn();
@@ -69,7 +57,13 @@ class AuraSqlModule extends AbstractModule
         $this->bind()->annotatedWith('pdo_queries')->toInstance($this->queries);
         $this->bind(ExtendedPdoInterface::class)->toConstructor(
             ExtendedPdo::class,
-            'dsn=pdo_dsn,username=pdo_user,password=pdo_pass,options=pdo_options,queries=pdo_queries',
+            [
+                'dsn' => 'pdo_dsn',
+                'username' => 'pdo_user',
+                'password' => 'pdo_pass',
+                'options' => 'pdo_options',
+                'queries' => 'pdo_queries',
+            ],
         )->in(Scope::SINGLETON);
     }
 

--- a/src/AuraSqlQueryDeleteProvider.php
+++ b/src/AuraSqlQueryDeleteProvider.php
@@ -6,26 +6,26 @@ namespace Ray\AuraSqlModule;
 
 use Aura\SqlQuery\Common\DeleteInterface;
 use Aura\SqlQuery\QueryFactory;
+use Override;
 use Ray\AuraSqlModule\Annotation\AuraSqlQueryConfig;
 use Ray\Di\ProviderInterface;
 
 /** @implements ProviderInterface<DeleteInterface> */
-class AuraSqlQueryDeleteProvider implements ProviderInterface
+final readonly class AuraSqlQueryDeleteProvider implements ProviderInterface
 {
-    private string $db;
-
     /** @param string $db The database type */
-    #[AuraSqlQueryConfig]
-    public function __construct(string $db)
-    {
-        $this->db = $db;
+    public function __construct(
+        #[AuraSqlQueryConfig]
+        private string $db
+    ) {
     }
 
     /**
      * {@inheritDoc}
      */
+    #[Override]
     public function get(): DeleteInterface
     {
-        return (new QueryFactory($this->db))->newDelete();
+        return new QueryFactory($this->db)->newDelete();
     }
 }

--- a/src/AuraSqlQueryInsertProvider.php
+++ b/src/AuraSqlQueryInsertProvider.php
@@ -6,26 +6,26 @@ namespace Ray\AuraSqlModule;
 
 use Aura\SqlQuery\Common\InsertInterface;
 use Aura\SqlQuery\QueryFactory;
+use Override;
 use Ray\AuraSqlModule\Annotation\AuraSqlQueryConfig;
 use Ray\Di\ProviderInterface;
 
 /** @implements ProviderInterface<InsertInterface> */
-class AuraSqlQueryInsertProvider implements ProviderInterface
+final readonly class AuraSqlQueryInsertProvider implements ProviderInterface
 {
-    private string $db;
-
     /** @param string $db The database type */
-    #[AuraSqlQueryConfig]
-    public function __construct(string $db)
-    {
-        $this->db = $db;
+    public function __construct(
+        #[AuraSqlQueryConfig]
+        private string $db
+    ) {
     }
 
     /**
      * {@inheritDoc}
      */
+    #[Override]
     public function get(): InsertInterface
     {
-        return (new QueryFactory($this->db))->newInsert();
+        return new QueryFactory($this->db)->newInsert();
     }
 }

--- a/src/AuraSqlQuerySelectProvider.php
+++ b/src/AuraSqlQuerySelectProvider.php
@@ -6,26 +6,26 @@ namespace Ray\AuraSqlModule;
 
 use Aura\SqlQuery\Common\SelectInterface;
 use Aura\SqlQuery\QueryFactory;
+use Override;
 use Ray\AuraSqlModule\Annotation\AuraSqlQueryConfig;
 use Ray\Di\ProviderInterface;
 
 /** @implements ProviderInterface<SelectInterface> */
-class AuraSqlQuerySelectProvider implements ProviderInterface
+final readonly class AuraSqlQuerySelectProvider implements ProviderInterface
 {
-    private string $db;
-
     /** @param string $db The database type */
-    #[AuraSqlQueryConfig()]
-    public function __construct($db)
-    {
-        $this->db = $db;
+    public function __construct(
+        #[AuraSqlQueryConfig]
+        private string $db
+    ) {
     }
 
     /**
      * {@inheritDoc}
      */
+    #[Override]
     public function get(): SelectInterface
     {
-        return (new QueryFactory($this->db))->newSelect();
+        return new QueryFactory($this->db)->newSelect();
     }
 }

--- a/src/AuraSqlQueryUpdateProvider.php
+++ b/src/AuraSqlQueryUpdateProvider.php
@@ -6,26 +6,26 @@ namespace Ray\AuraSqlModule;
 
 use Aura\SqlQuery\Common\UpdateInterface;
 use Aura\SqlQuery\QueryFactory;
+use Override;
 use Ray\AuraSqlModule\Annotation\AuraSqlQueryConfig;
 use Ray\Di\ProviderInterface;
 
 /** @implements ProviderInterface<UpdateInterface> */
-class AuraSqlQueryUpdateProvider implements ProviderInterface
+final readonly class AuraSqlQueryUpdateProvider implements ProviderInterface
 {
-    private string $db;
-
     /** @param string $db The database type */
-    #[AuraSqlQueryConfig]
-    public function __construct($db)
-    {
-        $this->db = $db;
+    public function __construct(
+        #[AuraSqlQueryConfig]
+        private string $db
+    ) {
     }
 
     /**
      * {@inheritDoc}
      */
+    #[Override]
     public function get(): UpdateInterface
     {
-        return (new QueryFactory($this->db))->newUpdate();
+        return new QueryFactory($this->db)->newUpdate();
     }
 }

--- a/src/AuraSqlReplicationModule.php
+++ b/src/AuraSqlReplicationModule.php
@@ -6,44 +6,62 @@ namespace Ray\AuraSqlModule;
 
 use Aura\Sql\ConnectionLocatorInterface;
 use Aura\Sql\ExtendedPdoInterface;
+use Override;
 use Ray\AuraSqlModule\Annotation\ReadOnlyConnection;
 use Ray\AuraSqlModule\Annotation\WriteConnection;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 
-class AuraSqlReplicationModule extends AbstractModule
+final class AuraSqlReplicationModule extends AbstractModule
 {
-    private ConnectionLocatorInterface $connectionLocator;
-    private string $qualifer;
-
     public function __construct(
-        ConnectionLocatorInterface $connectionLocator,
-        string $qualifer = '',
+        private readonly ConnectionLocatorInterface $connectionLocator,
+        private readonly string $qualifer = '',
         ?AbstractModule $module = null
     ) {
-        $this->connectionLocator = $connectionLocator;
-        $this->qualifer = $qualifer;
-
         parent::__construct($module);
     }
 
     /**
      * {@inheritDoc}
      */
+    #[Override]
     protected function configure(): void
     {
+        if ($this->qualifer === '') {
+            $this->configureWithoutQualifier();
+        } else {
+            $this->configureWithQualifier();
+        }
+
+        // @ReadOnlyConnection @WriteConnection
+        $this->installReadWriteConnection();
+    }
+
+    private function configureWithoutQualifier(): void
+    {
         $this->bind(ConnectionLocatorInterface::class)
+            ->toInstance($this->connectionLocator);
+
+        // ReadOnlyConnection when GET, otherwise WriteConnection
+        $this->bind(ExtendedPdoInterface::class)
+            ->toProvider(AuraSqlReplicationDbProvider::class, '')
+            ->in(Scope::SINGLETON);
+    }
+
+    private function configureWithQualifier(): void
+    {
+        $this->bind(ConnectionLocatorInterface::class)
+            /** @phpstan-ignore argument.type */
             ->annotatedWith($this->qualifer)
             ->toInstance($this->connectionLocator);
 
         // ReadOnlyConnection when GET, otherwise WriteConnection
         $this->bind(ExtendedPdoInterface::class)
+            /** @phpstan-ignore argument.type */
             ->annotatedWith($this->qualifer)
             ->toProvider(AuraSqlReplicationDbProvider::class, $this->qualifer)
             ->in(Scope::SINGLETON);
-
-        // @ReadOnlyConnection @WriteConnection
-        $this->installReadWriteConnection();
     }
 
     protected function installReadWriteConnection(): void

--- a/src/NamedPdoEnvModule.php
+++ b/src/NamedPdoEnvModule.php
@@ -10,7 +10,7 @@ use Ray\Di\AbstractModule;
 
 final class NamedPdoEnvModule extends AbstractModule
 {
-    public const string PARSE_PDO_DSN_REGEX = '/(.*?)\:(host|server)=.*?;(.*)/i';
+    public const PARSE_PDO_DSN_REGEX = '/(.*?)\:(host|server)=.*?;(.*)/i';
 
     /**
      * @param string              $qualifer Qualifer for ExtendedPdoInterface

--- a/src/NamedPdoEnvModule.php
+++ b/src/NamedPdoEnvModule.php
@@ -5,56 +5,40 @@ declare(strict_types=1);
 namespace Ray\AuraSqlModule;
 
 use Aura\Sql\ExtendedPdoInterface;
+use Override;
 use Ray\Di\AbstractModule;
 
-class NamedPdoEnvModule extends AbstractModule
+final class NamedPdoEnvModule extends AbstractModule
 {
-    public const PARSE_PDO_DSN_REGEX = '/(.*?)\:(host|server)=.*?;(.*)/i';
-
-    private string $qualifer;
-    private string $dsn;
-    private string $username;
-    private string $password;
-    private string $slave;
-
-    /** @var array<string> */
-    private array $options;
-
-    /** @var array<string> */
-    private array $queries;
+    public const string PARSE_PDO_DSN_REGEX = '/(.*?)\:(host|server)=.*?;(.*)/i';
 
     /**
-     * @param string        $qualifer Qualifer for ExtendedPdoInterface
-     * @param string        $dsn      Data Source Name (DSN)
-     * @param string        $username User name for the DSN string
-     * @param string        $password Password for the DSN string
-     * @param string        $slave    Comma separated slave host list
-     * @param array<string> $options  A key=>value array of driver-specific connection options
-     * @param array<string> $queries  Queries to execute after the connection.
+     * @param string              $qualifer Qualifer for ExtendedPdoInterface
+     * @param string              $dsn      Data Source Name (DSN)
+     * @param string              $username User name for the DSN string
+     * @param string              $password Password for the DSN string
+     * @param string              $slave    Comma separated slave host list
+     * @param array<string,mixed> $options  A key=>value array of driver-specific connection options
+     * @param array<string>       $queries  Queries to execute after the connection.
      */
     public function __construct(
-        string $qualifer,
-        string $dsn,
-        string $username = '',
-        string $password = '',
-        string $slave = '',
-        array $options = [],
-        array $queries = []
+        private readonly string $qualifer,
+        private readonly string $dsn,
+        private readonly string $username = '',
+        private readonly string $password = '',
+        private readonly string $slave = '',
+        /** @var array<string, mixed> */
+        private readonly array $options = [],
+        /** @var array<string> */
+        private readonly array $queries = []
     ) {
-        $this->qualifer = $qualifer;
-        $this->dsn = $dsn;
-        $this->username = $username;
-        $this->password = $password;
-        $this->slave = $slave;
-        $this->options = $options;
-        $this->queries = $queries;
-
         parent::__construct();
     }
 
     /**
      * {@inheritDoc}
      */
+    #[Override]
     protected function configure(): void
     {
         $this->slave ? $this->configureMasterSlaveDsn()
@@ -62,6 +46,15 @@ class NamedPdoEnvModule extends AbstractModule
     }
 
     private function configureSingleDsn(): void
+    {
+        if ($this->qualifer === '') {
+            $this->configureSingleDsnWithoutQualifier();
+        } else {
+            $this->configureSingleDsnWithQualifier();
+        }
+    }
+
+    private function configureSingleDsnWithoutQualifier(): void
     {
         $connection = new EnvConnection(
             $this->dsn,
@@ -71,11 +64,34 @@ class NamedPdoEnvModule extends AbstractModule
             $this->options,
             $this->queries,
         );
-        $this->bind(EnvConnection::class)->annotatedWith($this->qualifer)->toInstance($connection);
-        $this->bind(ExtendedPdoInterface::class)->annotatedWith($this->qualifer)->toProvider(
+        $this->bind(EnvConnection::class)->toInstance($connection);
+        $this->bind(ExtendedPdoInterface::class)->toProvider(
             NamedExtendedPdoProvider::class,
-            $this->qualifer,
+            '',
         );
+    }
+
+    private function configureSingleDsnWithQualifier(): void
+    {
+        $connection = new EnvConnection(
+            $this->dsn,
+            null,
+            $this->username,
+            $this->password,
+            $this->options,
+            $this->queries,
+        );
+        $this->bind(EnvConnection::class)
+            /** @phpstan-ignore argument.type */
+            ->annotatedWith($this->qualifer)
+            ->toInstance($connection);
+        $this->bind(ExtendedPdoInterface::class)
+            /** @phpstan-ignore argument.type */
+            ->annotatedWith($this->qualifer)
+            ->toProvider(
+                NamedExtendedPdoProvider::class,
+                $this->qualifer,
+            );
     }
 
     private function configureMasterSlaveDsn(): void

--- a/src/NamedPdoModule.php
+++ b/src/NamedPdoModule.php
@@ -14,7 +14,7 @@ use SensitiveParameter;
 
 final class NamedPdoModule extends AbstractModule
 {
-    public const string PARSE_PDO_DSN_REGEX = '/(.*?)\:(host|server)=.*?;(.*)/i';
+    public const PARSE_PDO_DSN_REGEX = '/(.*?)\:(host|server)=.*?;(.*)/i';
 
     /**
      * @param string              $qualifer Qualifer for ExtendedPdoInterface

--- a/src/NamedPdoModule.php
+++ b/src/NamedPdoModule.php
@@ -7,49 +7,42 @@ namespace Ray\AuraSqlModule;
 use Aura\Sql\ConnectionLocator;
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
+use InvalidArgumentException;
+use Override;
 use Ray\Di\AbstractModule;
+use SensitiveParameter;
 
-class NamedPdoModule extends AbstractModule
+final class NamedPdoModule extends AbstractModule
 {
-    public const PARSE_PDO_DSN_REGEX = '/(.*?)\:(host|server)=.*?;(.*)/i';
-
-    private string $qualifer;
-    private string $dsn;
-    private string $username;
-    private string $password;
-    private string $slave;
-
-    /** @var array<string> */
-    private array $options;
-
-    /** @var array<string> */
-    private array $queries;
+    public const string PARSE_PDO_DSN_REGEX = '/(.*?)\:(host|server)=.*?;(.*)/i';
 
     /**
-     * @param string        $qualifer Qualifer for ExtendedPdoInterface
-     * @param string        $dsn      Data Source Name (DSN)
-     * @param string        $username User name for the DSN string
-     * @param string        $password Password for the DSN string
-     * @param string        $slave    Comma separated slave host list
-     * @param array<string> $options  A key=>value array of driver-specific connection options
-     * @param array<string> $queries  Queries to execute after the connection.
+     * @param string              $qualifer Qualifer for ExtendedPdoInterface
+     * @param string              $dsn      Data Source Name (DSN)
+     * @param string              $username User name for the DSN string
+     * @param string              $password Password for the DSN string
+     * @param string              $slave    Comma separated slave host list
+     * @param array<string,mixed> $options  A key=>value array of driver-specific connection options
+     * @param array<string>       $queries  Queries to execute after the connection.
      */
     public function __construct(
-        string $qualifer,
-        string $dsn,
-        string $username = '',
-        string $password = '',
-        string $slave = '',
-        array $options = [],
-        array $queries = []
+        private readonly string $qualifer,
+        private readonly string $dsn,
+        private readonly string $username = '',
+        #[SensitiveParameter]
+        private readonly string $password = '',
+        private readonly string $slave = '',
+        /** @var array<string, mixed> */
+        private readonly array $options = [],
+        /** @var array<string> */
+        private readonly array $queries = []
     ) {
-        $this->qualifer = $qualifer;
-        $this->dsn = $dsn;
-        $this->username = $username;
-        $this->password = $password;
-        $this->slave = $slave;
-        $this->options = $options;
-        $this->queries = $queries;
+        if ($this->qualifer === '') {
+            throw new InvalidArgumentException(
+                'NamedPdoModule requires a non-empty qualifier. ' .
+                'Use AuraSqlModule instead for unqualified bindings.',
+            );
+        }
 
         parent::__construct();
     }
@@ -57,6 +50,7 @@ class NamedPdoModule extends AbstractModule
     /**
      * {@inheritDoc}
      */
+    #[Override]
     protected function configure(): void
     {
         $this->slave ? $this->configureMasterSlaveDsn()
@@ -69,11 +63,19 @@ class NamedPdoModule extends AbstractModule
             ->annotatedWith($this->qualifer)
             ->toConstructor(
                 ExtendedPdo::class,
-                "dsn={$this->qualifer}_dsn,username={$this->qualifer}_username,password={$this->qualifer}_password",
+                [
+                    'dsn' => "{$this->qualifer}_dsn",
+                    'username' => "{$this->qualifer}_username",
+                    'password' => "{$this->qualifer}_password",
+                    'driver_options' => "{$this->qualifer}_options",
+                    'after_connect' => "{$this->qualifer}_queries",
+                ],
             );
         $this->bind()->annotatedWith("{$this->qualifer}_dsn")->toInstance($this->dsn);
         $this->bind()->annotatedWith("{$this->qualifer}_username")->toInstance($this->username);
         $this->bind()->annotatedWith("{$this->qualifer}_password")->toInstance($this->password);
+        $this->bind()->annotatedWith("{$this->qualifer}_options")->toInstance($this->options);
+        $this->bind()->annotatedWith("{$this->qualifer}_queries")->toInstance($this->queries);
     }
 
     private function configureMasterSlaveDsn(): void

--- a/src/Pagerfanta/AuraSqlPager.php
+++ b/src/Pagerfanta/AuraSqlPager.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ray\AuraSqlModule\Pagerfanta;
 
 use Aura\Sql\ExtendedPdoInterface;
-use Pagerfanta\Adapter\AdapterInterface;
+use Override;
 use Pagerfanta\Exception\LogicException;
 use Pagerfanta\Pagerfanta;
 use Pagerfanta\View\ViewInterface;
@@ -18,13 +18,9 @@ use function assert;
 use function class_exists;
 
 /** @template T */
-class AuraSqlPager implements AuraSqlPagerInterface
+final class AuraSqlPager implements AuraSqlPagerInterface
 {
-    private ViewInterface $view;
     private ?RouteGeneratorInterface $routeGenerator = null;
-
-    /** @var array<array<string>> */
-    private array $viewOptions;
     private ExtendedPdoInterface $pdo;
     private string $sql;
     private ?string $entity = null;
@@ -35,12 +31,12 @@ class AuraSqlPager implements AuraSqlPagerInterface
     /** @phpstan-var positive-int */
     private int $paging;
 
-    /** @param array<array<string>> $viewOptions */
-    #[PagerViewOption('viewOptions')]
-    public function __construct(ViewInterface $view, array $viewOptions)
-    {
-        $this->view = $view;
-        $this->viewOptions = $viewOptions;
+    /** @param array<string, mixed> $viewOptions */
+    public function __construct(
+        private readonly ViewInterface $view,
+        #[PagerViewOption]
+        private readonly array $viewOptions
+    ) {
     }
 
     /**
@@ -48,6 +44,7 @@ class AuraSqlPager implements AuraSqlPagerInterface
      *
      * @phpstan-param positive-int $paging
      */
+    #[Override]
     public function init(ExtendedPdoInterface $pdo, $sql, array $params, $paging, RouteGeneratorInterface $routeGenerator, ?string $entity = null): void
     {
         $this->pdo = $pdo;
@@ -61,6 +58,7 @@ class AuraSqlPager implements AuraSqlPagerInterface
     /**
      * {@inheritDoc}
      */
+    #[Override]
     #[ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
@@ -72,6 +70,7 @@ class AuraSqlPager implements AuraSqlPagerInterface
      *
      * @phpstan-param positive-int $currentPage
      */
+    #[Override]
     public function offsetGet($currentPage): Page
     {
         if (! $this->routeGenerator instanceof RouteGeneratorInterface) {
@@ -97,6 +96,7 @@ class AuraSqlPager implements AuraSqlPagerInterface
     /**
      * {@inheritDoc}
      */
+    #[Override]
     public function offsetSet($offset, $value): void
     {
         throw new LogicException('read only');
@@ -105,17 +105,21 @@ class AuraSqlPager implements AuraSqlPagerInterface
     /**
      * {@inheritDoc}
      */
+    #[Override]
     public function offsetUnset($offset): void
     {
         throw new LogicException('read only');
     }
 
-    /** @return AdapterInterface<T> */
-    private function getPdoAdapter(): AdapterInterface
+    /** @return ExtendedPdoAdapter<T> */
+    private function getPdoAdapter(): ExtendedPdoAdapter
     {
         assert($this->entity === null || class_exists($this->entity));
         $fetcher = $this->entity ? new FetchEntity($this->pdo, $this->entity) : new FetchAssoc($this->pdo);
 
-        return new ExtendedPdoAdapter($this->pdo, $this->sql, $this->params, $fetcher);
+        /** @var ExtendedPdoAdapter<T> $adapter */
+        $adapter = new ExtendedPdoAdapter($this->pdo, $this->sql, $this->params, $fetcher);
+
+        return $adapter;
     }
 }

--- a/src/Pagerfanta/AuraSqlQueryPager.php
+++ b/src/Pagerfanta/AuraSqlQueryPager.php
@@ -8,6 +8,7 @@ use ArrayAccess;
 use Aura\Sql\ExtendedPdoInterface;
 use Aura\SqlQuery\Common\Select;
 use Aura\SqlQuery\Common\SelectInterface;
+use Override;
 use Pagerfanta\Exception\LogicException;
 use Pagerfanta\Pagerfanta;
 use Pagerfanta\View\ViewInterface;
@@ -18,31 +19,31 @@ use function array_keys;
 
 /** @implements ArrayAccess<int, Page> */
 
-class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, ArrayAccess
+final class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, ArrayAccess
 {
     private ExtendedPdoInterface $pdo;
-    private ViewInterface $view;
     private ?RouteGeneratorInterface $routeGenerator = null;
-
-    /** @var array<array<string>> */
-    private array $viewOptions;
     private SelectInterface $select;
 
     /** @phpstan-var positive-int */
     private int $paging;
 
-    /** @param array<array<string>> $viewOptions */
-    #[PagerViewOption('viewOptions')]
-    public function __construct(ViewInterface $view, array $viewOptions)
-    {
-        $this->view = $view;
-        $this->viewOptions = $viewOptions;
+    /** @param array<string, mixed> $viewOptions */
+    public function __construct(
+        private readonly ViewInterface $view,
+        #[PagerViewOption]
+        private readonly array $viewOptions
+    ) {
     }
 
     /**
      * @phpstan-param positive-int $paging
+     *
+     * @return AuraSqlQueryPagerInterface
+     *
      * {@inheritDoc}
      */
+    #[Override]
     public function init(ExtendedPdoInterface $pdo, SelectInterface $select, int $paging, RouteGeneratorInterface $routeGenerator)
     {
         $this->pdo = $pdo;
@@ -57,6 +58,7 @@ class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, ArrayAccess
      * @phpstan-param positive-int $page
      * {@inheritDoc}
      */
+    #[Override]
     public function offsetGet($page): Page
     {
         if (! $this->routeGenerator instanceof RouteGeneratorInterface) {
@@ -89,6 +91,7 @@ class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, ArrayAccess
     /**
      * {@inheritDoc}
      */
+    #[Override]
     public function offsetExists($offset): bool
     {
         throw new LogicException('unsupported');
@@ -97,6 +100,7 @@ class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, ArrayAccess
     /**
      * {@inheritDoc}
      */
+    #[Override]
     public function offsetSet($offset, $value): void
     {
         throw new LogicException('read only');
@@ -105,6 +109,7 @@ class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, ArrayAccess
     /**
      * {@inheritDoc}
      */
+    #[Override]
     public function offsetUnset($offset): void
     {
         throw new LogicException('read only');

--- a/tests/AuraSqlModuleTest.php
+++ b/tests/AuraSqlModuleTest.php
@@ -20,7 +20,7 @@ class AuraSqlModuleTest extends TestCase
 {
     public function testModule()
     {
-        $instance = new Injector(new AuraSqlModule('sqlite::memory:'), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class);
+        $instance = (new Injector(new AuraSqlModule('sqlite::memory:'), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class);
         $this->assertInstanceOf(ExtendedPdo::class, $instance);
     }
 
@@ -36,21 +36,21 @@ class AuraSqlModuleTest extends TestCase
 
     public function testMysql()
     {
-        $fakeInject = new Injector(new AuraSqlModule('mysql:host=localhost;dbname=master'), __DIR__ . '/tmp')->getInstance(FakeQueryInject::class);
+        $fakeInject = (new Injector(new AuraSqlModule('mysql:host=localhost;dbname=master'), __DIR__ . '/tmp'))->getInstance(FakeQueryInject::class);
         [$db] = $fakeInject->get();
         $this->assertSame('mysql', $db);
     }
 
     public function testPgsql()
     {
-        $fakeInject = new Injector(new AuraSqlModule('pgsql:host=localhost;dbname=master'), __DIR__ . '/tmp')->getInstance(FakeQueryInject::class);
+        $fakeInject = (new Injector(new AuraSqlModule('pgsql:host=localhost;dbname=master'), __DIR__ . '/tmp'))->getInstance(FakeQueryInject::class);
         [$db] = $fakeInject->get();
         $this->assertSame('pgsql', $db);
     }
 
     public function testSqlite()
     {
-        $fakeInject = new Injector(new AuraSqlModule('sqlite:memory:'), __DIR__ . '/tmp')->getInstance(FakeQueryInject::class);
+        $fakeInject = (new Injector(new AuraSqlModule('sqlite:memory:'), __DIR__ . '/tmp'))->getInstance(FakeQueryInject::class);
         [$db] = $fakeInject->get();
         $this->assertSame('sqlite', $db);
     }
@@ -69,7 +69,7 @@ class AuraSqlModuleTest extends TestCase
 
     public function testNoHost()
     {
-        $instance = new Injector(new FakeQualifierModule(), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class);
+        $instance = (new Injector(new FakeQualifierModule(), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class);
         /** @var ExtendedPdo $instance */
         $this->assertSame('sqlite::memory:', $this->getDsn($instance));
     }

--- a/tests/AuraSqlModuleTest.php
+++ b/tests/AuraSqlModuleTest.php
@@ -8,47 +8,49 @@ use Aura\Sql\ConnectionLocatorInterface;
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
 use PHPUnit\Framework\TestCase;
-use Ray\Compiler\DiCompiler;
-use Ray\Compiler\ScriptInjector;
+use Ray\Compiler\CompiledInjector;
+use Ray\Compiler\Compiler;
 use Ray\Di\Injector;
 use Ray\Di\Instance;
 use ReflectionProperty;
 
 use function assert;
-use function get_class;
 
 class AuraSqlModuleTest extends TestCase
 {
     public function testModule()
     {
-        $instance = (new Injector(new AuraSqlModule('sqlite::memory:'), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class);
+        $instance = new Injector(new AuraSqlModule('sqlite::memory:'), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class);
         $this->assertInstanceOf(ExtendedPdo::class, $instance);
     }
 
     public function testCompile()
     {
-        (new DiCompiler(new AuraSqlModule('sqlite::memory:'), __DIR__ . '/tmp'))->compile();
-        $pdo = (new ScriptInjector(__DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class);
+        $compiler = new Compiler();
+        $scriptDir = __DIR__ . '/tmp';
+        $compiler->compile(new AuraSqlModule('sqlite::memory:'), $scriptDir);
+        $injector = new CompiledInjector($scriptDir);
+        $pdo = $injector->getInstance(ExtendedPdoInterface::class);
         $this->assertInstanceOf(ExtendedPdoInterface::class, $pdo);
     }
 
     public function testMysql()
     {
-        $fakeInject = (new Injector(new AuraSqlModule('mysql:host=localhost;dbname=master'), __DIR__ . '/tmp'))->getInstance(FakeQueryInject::class);
+        $fakeInject = new Injector(new AuraSqlModule('mysql:host=localhost;dbname=master'), __DIR__ . '/tmp')->getInstance(FakeQueryInject::class);
         [$db] = $fakeInject->get();
         $this->assertSame('mysql', $db);
     }
 
     public function testPgsql()
     {
-        $fakeInject = (new Injector(new AuraSqlModule('pgsql:host=localhost;dbname=master'), __DIR__ . '/tmp'))->getInstance(FakeQueryInject::class);
+        $fakeInject = new Injector(new AuraSqlModule('pgsql:host=localhost;dbname=master'), __DIR__ . '/tmp')->getInstance(FakeQueryInject::class);
         [$db] = $fakeInject->get();
         $this->assertSame('pgsql', $db);
     }
 
     public function testSqlite()
     {
-        $fakeInject = (new Injector(new AuraSqlModule('sqlite:memory:'), __DIR__ . '/tmp'))->getInstance(FakeQueryInject::class);
+        $fakeInject = new Injector(new AuraSqlModule('sqlite:memory:'), __DIR__ . '/tmp')->getInstance(FakeQueryInject::class);
         [$db] = $fakeInject->get();
         $this->assertSame('sqlite', $db);
     }
@@ -67,15 +69,14 @@ class AuraSqlModuleTest extends TestCase
 
     public function testNoHost()
     {
-        $instance = (new Injector(new FakeQualifierModule(), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class);
+        $instance = new Injector(new FakeQualifierModule(), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class);
         /** @var ExtendedPdo $instance */
         $this->assertSame('sqlite::memory:', $this->getDsn($instance));
     }
 
     private function getDsn(ExtendedPdo $pdo): string
     {
-        $prop = new ReflectionProperty(get_class($pdo), 'args');
-        $prop->setAccessible(true);
+        $prop = new ReflectionProperty($pdo::class, 'args');
         $args = $prop->getValue($pdo);
 
         return $args[0]; // dsn

--- a/tests/Fake/FakeLogDb.php
+++ b/tests/Fake/FakeLogDb.php
@@ -7,7 +7,7 @@ use Aura\Sql\ExtendedPdoInterface;
 use Ray\Di\Di\Named;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+#[Attribute(Attribute::TARGET_PARAMETER), Qualifier]
 final class FakeLogDb
 {
 }

--- a/tests/Fake/FakeLogDbInject.php
+++ b/tests/Fake/FakeLogDbInject.php
@@ -9,7 +9,7 @@ use Ray\Di\Di\Named;
 use Ray\Di\Di\Qualifier;
 use Ray\Di\InjectorInterface;
 
-#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER), Qualifier]
 final class FakeLogDbInject implements InjectInterface
 {
     public $optional = true;

--- a/tests/Fake/FakeMultiDb.php
+++ b/tests/Fake/FakeMultiDb.php
@@ -16,9 +16,14 @@ class FakeMultiDb
     protected $pdo2;
     protected $pdo3;
 
-    #[Named('pdo1=pdo1,pdo2=pdo2,pdo3=pdo3')]
-    public function __construct(ExtendedPdoInterface $pdo1, ExtendedPdoInterface $pdo2, ExtendedPdoInterface $pdo3)
-    {
+    public function __construct(
+        #[Named('pdo1')]
+        ExtendedPdoInterface $pdo1,
+        #[Named('pdo2')]
+        ExtendedPdoInterface $pdo2,
+        #[Named('pdo3')]
+        ExtendedPdoInterface $pdo3
+    ) {
         $this->pdo1 = $pdo1;
         $this->pdo2 = $pdo2;
         $this->pdo3 = $pdo3;

--- a/tests/Fake/FakeName.php
+++ b/tests/Fake/FakeName.php
@@ -12,21 +12,26 @@ class FakeName
     public $pdoAnno;
     public $pdoSetterInject;
 
-    #[Named('log_db')]
-    public function __construct(ExtendedPdoInterface $pdo)
-    {
+    public function __construct(
+        #[Named('log_db')]
+        ExtendedPdoInterface $pdo
+    ) {
         $this->pdo = $pdo;
     }
 
-    #[Inject, FakeLogDb]
-    public function setFakeDb(ExtendedPdoInterface $pdo)
-    {
+    #[Inject]
+    public function setFakeDb(
+        #[FakeLogDb]
+        ExtendedPdoInterface $pdo
+    ) {
         $this->pdoAnno = $pdo;
     }
 
     #[FakeLogDbInject]
-    public function setFakeDbWithInjectAnnotation(ExtendedPdoInterface $pdo)
-    {
+    public function setFakeDbWithInjectAnnotation(
+        #[FakeLogDbInject]
+        ExtendedPdoInterface $pdo
+    ) {
         $this->pdoSetterInject = $pdo;
     }
 }

--- a/tests/Fake/FakeQueryInject.php
+++ b/tests/Fake/FakeQueryInject.php
@@ -11,13 +11,11 @@ class FakeQueryInject
     use AuraSqlUpdateInject;
     use AuraSqlDeleteInject;
 
-    private string $db;
-
     /** @param string $db */
-    #[AuraSqlQueryConfig]
-    public function __construct($db)
-    {
-        $this->db = $db;
+    public function __construct(
+        #[AuraSqlQueryConfig]
+        private string $db
+    ) {
     }
 
     public function get()

--- a/tests/NamedPdoModuleTest.php
+++ b/tests/NamedPdoModuleTest.php
@@ -6,20 +6,28 @@ namespace Ray\AuraSqlModule;
 
 use Aura\Sql\ExtendedPdo;
 use Aura\Sql\ExtendedPdoInterface;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 use ReflectionProperty;
 
 use function assert;
-use function get_class;
 
 class NamedPdoModuleTest extends TestCase
 {
     public function testModule()
     {
         $qualifer = 'log_db';
-        $instance = (new Injector(new NamedPdoModule($qualifer, 'sqlite::memory:'), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class, $qualifer);
+        $instance = new Injector(new NamedPdoModule($qualifer, 'sqlite::memory:'), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class, $qualifer);
         $this->assertInstanceOf(ExtendedPdo::class, $instance);
+    }
+
+    public function testEmptyQualifierThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('NamedPdoModule requires a non-empty qualifier. Use AuraSqlModule instead for unqualified bindings.');
+
+        new NamedPdoModule('', 'sqlite::memory:');
     }
 
     public function testFakeName()
@@ -35,7 +43,7 @@ class NamedPdoModuleTest extends TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $qualifer = 'log_db';
-        $instance = (new Injector(new FakeNamedReplicationModule(), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class, $qualifer);
+        $instance = new Injector(new FakeNamedReplicationModule(), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class, $qualifer);
         assert($instance instanceof ExtendedPdo);
         $this->assertInstanceOf(ExtendedPdo::class, $instance);
 //        $this->assertSame('mysql:host=localhost;dbname=db', $instance->getDsn());
@@ -45,7 +53,7 @@ class NamedPdoModuleTest extends TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $qualifer = 'log_db';
-        $instance = (new Injector(new FakeNamedReplicationModule(), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class, $qualifer);
+        $instance = new Injector(new FakeNamedReplicationModule(), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class, $qualifer);
         $this->assertInstanceOf(ExtendedPdo::class, $instance);
         $this->assertStringContainsString('mysql:host=slave', $this->getDsn($instance));
     }
@@ -53,15 +61,14 @@ class NamedPdoModuleTest extends TestCase
     public function testNoHost()
     {
         $qualifer = 'log_db';
-        $instance = (new Injector(new FakeNamedQualifierModule(), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class, $qualifer);
+        $instance = new Injector(new FakeNamedQualifierModule(), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class, $qualifer);
         /** @var ExtendedPdo $instance */
         $this->assertSame('mysql:host=slave1;dbname=master', $this->getDsn($instance));
     }
 
     private function getDsn(ExtendedPdo $pdo): string
     {
-        $prop = new ReflectionProperty(get_class($pdo), 'args');
-        $prop->setAccessible(true);
+        $prop = new ReflectionProperty($pdo::class, 'args');
         $args = $prop->getValue($pdo);
 
         return $args[0]; // dsn

--- a/tests/NamedPdoModuleTest.php
+++ b/tests/NamedPdoModuleTest.php
@@ -18,7 +18,7 @@ class NamedPdoModuleTest extends TestCase
     public function testModule()
     {
         $qualifer = 'log_db';
-        $instance = new Injector(new NamedPdoModule($qualifer, 'sqlite::memory:'), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class, $qualifer);
+        $instance = (new Injector(new NamedPdoModule($qualifer, 'sqlite::memory:'), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class, $qualifer);
         $this->assertInstanceOf(ExtendedPdo::class, $instance);
     }
 
@@ -43,7 +43,7 @@ class NamedPdoModuleTest extends TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $qualifer = 'log_db';
-        $instance = new Injector(new FakeNamedReplicationModule(), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class, $qualifer);
+        $instance = (new Injector(new FakeNamedReplicationModule(), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class, $qualifer);
         assert($instance instanceof ExtendedPdo);
         $this->assertInstanceOf(ExtendedPdo::class, $instance);
 //        $this->assertSame('mysql:host=localhost;dbname=db', $instance->getDsn());
@@ -53,7 +53,7 @@ class NamedPdoModuleTest extends TestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $qualifer = 'log_db';
-        $instance = new Injector(new FakeNamedReplicationModule(), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class, $qualifer);
+        $instance = (new Injector(new FakeNamedReplicationModule(), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class, $qualifer);
         $this->assertInstanceOf(ExtendedPdo::class, $instance);
         $this->assertStringContainsString('mysql:host=slave', $this->getDsn($instance));
     }
@@ -61,7 +61,7 @@ class NamedPdoModuleTest extends TestCase
     public function testNoHost()
     {
         $qualifer = 'log_db';
-        $instance = new Injector(new FakeNamedQualifierModule(), __DIR__ . '/tmp')->getInstance(ExtendedPdoInterface::class, $qualifer);
+        $instance = (new Injector(new FakeNamedQualifierModule(), __DIR__ . '/tmp'))->getInstance(ExtendedPdoInterface::class, $qualifer);
         /** @var ExtendedPdo $instance */
         $this->assertSame('mysql:host=slave1;dbname=master', $this->getDsn($instance));
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,14 +2,6 @@
 
 declare(strict_types=1);
 
-use Koriym\Attributes\AttributeReader;
-use Ray\ServiceLocator\ServiceLocator;
-
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-array_map('unlink', (array) glob(__DIR__ . '/tmp/*.{php,txt}', GLOB_BRACE));
-
-// no annotation in PHP 8
-if (PHP_MAJOR_VERSION >= 8) {
-    ServiceLocator::setReader(new AttributeReader());
-}
+array_map(unlink(...), (array) glob(__DIR__ . '/tmp/*.{php,txt}', GLOB_BRACE));


### PR DESCRIPTION
## Summary

This PR migrates Ray.AuraSqlModule 1.13.x to use parameter-level attributes for dependency injection, ensuring compatibility with Ray.Di 2.19.1.

This is a backport of #86 (1.16.0 release) adapted for PHP 8.0 compatibility.

## Breaking Changes

⚠️ **Requires Ray.Di ^2.19.1 and Ray.Aop ^2.19**

## Changes

### Attribute Definitions
Updated qualifier attributes to target parameters:
- `AuraSqlQueryConfig`: `TARGET_METHOD` → `TARGET_PARAMETER`
- `EnvAuth`: `TARGET_METHOD` → `TARGET_PARAMETER`
- `PagerViewOption`: `TARGET_PARAMETER`, made `$value` optional

### Module Configuration

#### Enhanced Validation
- **NamedPdoModule** validates non-empty qualifiers
  - Throws `InvalidArgumentException` with clear error message  
  - Directs users to `AuraSqlModule` for unqualified bindings

#### Array Format for toConstructor
Migrated from legacy string format to array format in all modules

#### Bug Fixes  
- Fixed `NamedPdoModule` to properly pass `$options` and `$queries` parameters

### Code Quality
- Eliminated conditional binding anti-patterns via method splitting
- Improved PHPStan compatibility

### Cleanup
- Removed deprecated `ServiceLocator` setup from tests
- Removed coverage configuration from `phpunit.xml.dist`

## Migration Guide

Update your dependencies:

```bash
composer require ray/di:^2.19.1 ray/aop:^2.19
```

No application code changes required - attribute migration is internal.

## Related

- Backport from ray-di/Ray.AuraSqlModule#86
- Depends on ray-di/Ray.Di#306 (Ray.Di 2.19.1)

## Summary by Sourcery

Backport Ray.AuraSqlModule migration to parameter-level DI attributes for compatibility with Ray.Di 2.19.1 and PHP 8.0 by refactoring modules, updating composer dependencies, fixing qualifier bindings, and aligning tests with the new Ray Compiler API

New Features:
- Migrate qualifier attributes (AuraSqlQueryConfig, EnvAuth, PagerViewOption, etc.) to target constructor parameters instead of methods
- Add validation to NamedPdoModule to enforce non-empty qualifiers with a clear exception message

Bug Fixes:
- Fix NamedPdoModule to correctly bind driver options and post-connect queries
- Correct NamedPdoEnvModule qualifier handling by splitting single-DSN configuration into qualified and unqualified methods

Enhancements:
- Convert string-based toConstructor bindings to array format across all modules
- Refactor modules into final classes with PHP 8 readonly properties and #[Override] annotations
- Improve PHPStan compatibility and eliminate conditional binding anti-patterns through method splitting

Build:
- Update composer.json to require ray/di ^2.19.1, ray/aop ^2.19 and add ray/compiler

Tests:
- Update tests to use Ray Compiler's CompiledInjector instead of DiCompiler/ScriptInjector
- Add test for empty qualifier exception in NamedPdoModule

Chores:
- Remove deprecated ServiceLocator setup and PHPUnit coverage configuration from tests
- Clean up bootstrap and tmp directory cleanup logic