### PR TITLE
Add Psalm taint annotations for SQL injection analysis

### DIFF
--- a/src/Pagerfanta/AuraSqlPagerFactory.php
+++ b/src/Pagerfanta/AuraSqlPagerFactory.php
@@ -15,6 +15,7 @@ final class AuraSqlPagerFactory implements AuraSqlPagerFactoryInterface
 
     /**
      * {@inheritDoc}
+     * @psalm-taint-sink sql $sql
      */
     #[Override]
     public function newInstance(ExtendedPdoInterface $pdo, string $sql, array $params, int $paging, string $uriTemplate, ?string $entity = null): AuraSqlPagerInterface

--- a/src/Pagerfanta/AuraSqlPagerFactory.php
+++ b/src/Pagerfanta/AuraSqlPagerFactory.php
@@ -15,6 +15,7 @@ final class AuraSqlPagerFactory implements AuraSqlPagerFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
      * @psalm-taint-sink sql $sql
      */
     #[Override]

--- a/src/Pagerfanta/ExtendedPdoAdapter.php
+++ b/src/Pagerfanta/ExtendedPdoAdapter.php
@@ -31,6 +31,7 @@ final class ExtendedPdoAdapter implements AdapterInterface
 
     /**
      * @param array<mixed> $params
+     *
      * @psalm-taint-sink sql $sql
      */
     public function __construct(

--- a/src/Pagerfanta/ExtendedPdoAdapter.php
+++ b/src/Pagerfanta/ExtendedPdoAdapter.php
@@ -29,7 +29,10 @@ final class ExtendedPdoAdapter implements AdapterInterface
 {
     private readonly FetcherInterface $fetcher;
 
-    /** @param array<mixed> $params */
+    /**
+     * @param array<mixed> $params
+     * @psalm-taint-sink sql $sql
+     */
     public function __construct(
         private readonly ExtendedPdoInterface $pdo,
         private readonly string $sql,

--- a/src/Pagerfanta/ExtendedPdoAdapter.php
+++ b/src/Pagerfanta/ExtendedPdoAdapter.php
@@ -77,9 +77,6 @@ final class ExtendedPdoAdapter implements AdapterInterface
     /**
      * {@inheritDoc}
      *
-     * @param int $offset
-     * @param int $length
-     *
      * @return array<mixed>
      */
     #[Override]

--- a/src/Pagerfanta/FetchAssoc.php
+++ b/src/Pagerfanta/FetchAssoc.php
@@ -18,7 +18,6 @@ final class FetchAssoc implements FetcherInterface
      * {@inheritDoc}
      *
      * @psalm-taint-sink sql $sql
-     * @psalm-taint-escape sql
      */
     #[Override]
     public function __invoke(string $sql, array $params): array

--- a/src/Pagerfanta/FetchAssoc.php
+++ b/src/Pagerfanta/FetchAssoc.php
@@ -16,6 +16,8 @@ final class FetchAssoc implements FetcherInterface
 
     /**
      * {@inheritDoc}
+     * @psalm-taint-sink sql $sql
+     * @psalm-taint-escape sql
      */
     #[Override]
     public function __invoke(string $sql, array $params): array

--- a/src/Pagerfanta/FetchAssoc.php
+++ b/src/Pagerfanta/FetchAssoc.php
@@ -16,6 +16,7 @@ final class FetchAssoc implements FetcherInterface
 
     /**
      * {@inheritDoc}
+     *
      * @psalm-taint-sink sql $sql
      * @psalm-taint-escape sql
      */

--- a/src/Pagerfanta/FetchEntity.php
+++ b/src/Pagerfanta/FetchEntity.php
@@ -24,6 +24,7 @@ final class FetchEntity implements FetcherInterface
 
     /**
      * {@inheritDoc}
+     *
      * @psalm-taint-sink sql $sql
      * @psalm-taint-escape sql
      */

--- a/src/Pagerfanta/FetchEntity.php
+++ b/src/Pagerfanta/FetchEntity.php
@@ -26,7 +26,6 @@ final class FetchEntity implements FetcherInterface
      * {@inheritDoc}
      *
      * @psalm-taint-sink sql $sql
-     * @psalm-taint-escape sql
      */
     #[Override]
     public function __invoke(string $sql, array $params): array

--- a/src/Pagerfanta/FetchEntity.php
+++ b/src/Pagerfanta/FetchEntity.php
@@ -24,6 +24,8 @@ final class FetchEntity implements FetcherInterface
 
     /**
      * {@inheritDoc}
+     * @psalm-taint-sink sql $sql
+     * @psalm-taint-escape sql
      */
     #[Override]
     public function __invoke(string $sql, array $params): array


### PR DESCRIPTION
## Summary
- Add `@psalm-taint-sink sql` to mark SQL query parameters as SQL injection sinks
- Add `@psalm-taint-escape sql` to mark fetch methods as SQL escape points (prepared statements)

### Changed files
- `ExtendedPdoAdapter::__construct()` - marks `$sql` parameter as SQL sink
- `AuraSqlPagerFactory::newInstance()` - marks `$sql` parameter as SQL sink  
- `FetchAssoc::__invoke()` - marks as SQL sink and escape (uses prepared statements)
- `FetchEntity::__invoke()` - marks as SQL sink and escape (uses prepared statements)

These annotations enable Psalm's taint analysis to detect SQL injection vulnerabilities by tracking tainted data flow from sources to sinks.

## Summary by Sourcery

Annotate SQL-related methods and constructors with Psalm taint metadata to improve static detection of SQL injection risks.

Enhancements:
- Mark ExtendedPdoAdapter constructor SQL parameter as a Psalm SQL taint sink.
- Annotate FetchAssoc and FetchEntity invokers as both SQL taint sinks and SQL escape points for prepared queries.
- Mark AuraSqlPagerFactory::newInstance SQL argument as a Psalm SQL taint sink to support taint tracking across pager construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added static-analysis taint annotations to several pager, adapter, and fetch component docblocks to improve security metadata for developer tooling. These are documentation-only updates; no runtime behavior, public interfaces, method signatures, or error handling were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->