### PR TITLE
Document 1.13.x vs 1.x maintenance lines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,9 @@ An [Aura.Sql](https://github.com/auraphp/Aura.Sql) Module for [Ray.Di](https://g
 Two lines are maintained. **Pick by how your application declares metadata** — the required PHP version follows from the Aura.Sql major you depend on, not from this package directly.
 
 - **1.13.x** — use this if your application still relies on **Doctrine annotations** (`@Transactional`, `@Named` in docblocks). Depends on `ray/di` ^2.13, which ships `doctrine/annotations`. Supports Aura.Sql 4 and 5.
-- **1.x** (current) — **PHP attributes only** (`#[Transactional]`). Depends on `ray/di` ^2.16+, which dropped `doctrine/annotations`. Supports Aura.Sql 5 and 6.
+- **1.x** (current) — **PHP attributes only** (`#[Transactional]`). Depends on `ray/di` ^2.16+, which dropped `doctrine/annotations`. Supports Aura.Sql 5 (PHP 8.1–8.3) and Aura.Sql 6 (PHP 8.4+, covering the PDO BC break introduced in PHP 8.4).
 
-The effective PHP requirement comes from Aura.Sql:
-
-| Aura.Sql | PHP      |
-|----------|----------|
-| 4.x      | 7.2+     |
-| 5.x      | 8.1+     |
-| 6.x      | 8.4+     |
+Composer resolves the matching Aura.Sql major automatically from your PHP version, so you normally don't need to think about it — the decisive question is annotations vs attributes.
 
 To pin to the maintenance line, use a tilde or wildcard constraint — `^1.13` would also match 1.14+ and pull you onto the 1.x line:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ Two lines are maintained. **Pick by how your application declares metadata** —
 - **1.13.x** — use this if your application still relies on **Doctrine annotations** (`@Transactional`, `@Named` in docblocks). Depends on `ray/di` ^2.13, which ships `doctrine/annotations`. Supports Aura.Sql 4 and 5.
 - **1.x** (current) — **PHP attributes only** (`#[Transactional]`). Depends on `ray/di` ^2.16+, which dropped `doctrine/annotations`. Supports Aura.Sql 5 and 6.
 
-Effective PHP requirement comes from Aura.Sql: 4.x → PHP 7.2+, 5.x → PHP 8.1+, 6.x → PHP 8.4+.
+The effective PHP requirement comes from Aura.Sql:
+
+| Aura.Sql | PHP      |
+|----------|----------|
+| 4.x      | 7.2+     |
+| 5.x      | 8.1+     |
+| 6.x      | 8.4+     |
 
 To pin to the maintenance line, use a tilde or wildcard constraint — `^1.13` would also match 1.14+ and pull you onto the 1.x line:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@
 
 An [Aura.Sql](https://github.com/auraphp/Aura.Sql) Module for [Ray.Di](https://github.com/koriym/Ray.Di)
 
+## Versions
+
+Two lines are maintained. **Pick by how your application declares metadata** — the required PHP version follows from the Aura.Sql major you depend on, not from this package directly.
+
+- **1.13.x** — use this if your application still relies on **Doctrine annotations** (`@Transactional`, `@Named` in docblocks). Depends on `ray/di` ^2.13, which ships `doctrine/annotations`. Supports Aura.Sql 4 and 5.
+- **1.x** (current) — **PHP attributes only** (`#[Transactional]`). Depends on `ray/di` ^2.16+, which dropped `doctrine/annotations`. Supports Aura.Sql 5 and 6.
+
+Effective PHP requirement comes from Aura.Sql: 4.x → PHP 7.2+, 5.x → PHP 8.1+, 6.x → PHP 8.4+.
+
+To pin to the maintenance line, use a tilde or wildcard constraint — `^1.13` would also match 1.14+ and pull you onto the 1.x line:
+
+```json
+{
+    "require": {
+        "ray/aura-sql-module": "~1.13.1"
+    }
+}
+```
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a `Versions` section to README explaining the two maintenance lines
- Frame the decision around annotations vs attributes (the real differentiator) rather than PHP version, which Composer resolves automatically via Aura.Sql
- Note that `^1.13` would pull onto 1.x and show `~1.13.1` as the correct pin

## Background

- `1.13.x` depends on `ray/di` ^2.13, which still ships `doctrine/annotations`, so Doctrine-style `@Transactional` keeps working
- `1.x` depends on `ray/di` ^2.16+, where `doctrine/annotations` was dropped — PHP attributes only
- Aura.Sql 5 covers PHP 8.1–8.3; Aura.Sql 6 covers PHP 8.4+ (PDO BC break)

## Test plan

- [x] README renders on GitHub
- [x] Constraint example is accurate (`~1.13.1` locks to 1.13.x; `^1.13` does not)

## Summary by Sourcery

Document the two maintained 1.x release lines and their selection criteria in the README, clarifying annotation vs attribute usage, Aura.Sql/PHP version implications, and providing example Composer constraints.

Documentation:
- Add a README section describing the 1.13.x and 1.x maintenance lines, their dependencies, and when to choose each based on Doctrine annotations vs PHP attributes.
- Document Composer constraint examples to correctly pin projects to the desired maintenance line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added version guidance documentation for two maintained release lines: version 1.13.x for Doctrine docblock annotations and version 1.x for PHP attributes, including dependency requirements, supported Aura.Sql versions, and composer constraints for version selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->