### PR TITLE
Add nbPages property to Page

### DIFF
--- a/src/Pagerfanta/AuraSqlPager.php
+++ b/src/Pagerfanta/AuraSqlPager.php
@@ -89,6 +89,7 @@ final class AuraSqlPager implements AuraSqlPagerInterface
         $page->hasPrevious = $pagerfanta->hasPreviousPage();
         $page->data = $pagerfanta->getCurrentPageResults();
         $page->total = $pagerfanta->getNbResults();
+        $page->nbPages = $pagerfanta->getNbPages();
 
         return $page;
     }

--- a/src/Pagerfanta/AuraSqlQueryPager.php
+++ b/src/Pagerfanta/AuraSqlQueryPager.php
@@ -84,6 +84,7 @@ final class AuraSqlQueryPager implements AuraSqlQueryPagerInterface, ArrayAccess
         $pager->hasPrevious = $pagerfanta->hasPreviousPage();
         $pager->data = $pagerfanta->getCurrentPageResults();
         $pager->total = $pagerfanta->getNbResults();
+        $pager->nbPages = $pagerfanta->getNbPages();
 
         return $pager;
     }

--- a/src/Pagerfanta/Page.php
+++ b/src/Pagerfanta/Page.php
@@ -23,6 +23,9 @@ final class Page implements IteratorAggregate, Stringable
     /** @var int */
     public $total;
 
+    /** @var int */
+    public $nbPages;
+
     /** @var bool */
     public $hasNext;
 

--- a/tests/Pagerfanta/AuraSqlQueryPagerTest.php
+++ b/tests/Pagerfanta/AuraSqlQueryPagerTest.php
@@ -61,6 +61,7 @@ class AuraSqlQueryPagerTest extends AuraSqlQueryTestCase
         $this->assertSame(1, $post->maxPerPage);
         $this->assertSame(2, $post->current);
         $this->assertSame(50, $post->total);
+        $this->assertSame(50, $post->nbPages);
         $expected = [['username' => 'Jon Doe']];
         $this->assertSame($expected, $post->data);
     }


### PR DESCRIPTION
## Summary

`Pagerfanta` exposes `getNbPages()` (the total number of pages), but Ray's `Page` only surfaces `total` (the result count), never the page count. Every consumer therefore had to recompute `ceil(total / maxPerPage)` by hand, duplicating logic that already lives in `Pagerfanta`.

## Changes

- Add a public `$nbPages` property to `Page`.
- Populate it from `Pagerfanta::getNbPages()` in both `AuraSqlPager` and `AuraSqlQueryPager`, alongside the existing `total` assignment.

Non-breaking: only an additive property on a final value object.

## Verification

- phpunit: 76 tests, 146 assertions OK
- phpstan: OK
- psalm: OK
- phpcs: blocked by an existing tooling issue on PHP 8.5 (`No files were checked`); the change mirrors the existing property style.